### PR TITLE
chore: README rework, clang-format, dev workflow, docs strategy

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,28 +1,41 @@
+---
 Language: Cpp
-# BasedOnStyle:  WebKit
-# Adjusted for OpenFOAM coding standards
+# OpenFOAM Coding Style Guide Configuration
+# Compatible with clang-format 19.1.7
+# Reference: https://openfoam.org/dev/coding-style-guide/
+
+# Access modifiers at first indentation level
 AccessModifierOffset: -4
-AlignAfterOpenBracket: AlwaysBreak
+
+# Align arguments after opening bracket
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: None
 AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
 AlignConsecutiveDeclarations: None
 AlignEscapedNewlines: Right
-AlignOperands: DontAlign
-AlignTrailingComments: false
-AllowAllArgumentsOnNextLine: false
-AllowAllConstructorInitializersOnNextLine: false
-AllowAllParametersOfDeclarationOnNextLine: false
+AlignOperands: Align
+AlignTrailingComments: true
+
+# Allow arguments on next line
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: None
-AllowShortLambdasOnASingleLine: None
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: None
+
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: MultiLine
+AlwaysBreakTemplateDeclarations: Yes
+
 BinPackArguments: false
-BinPackParameters: OnePerLine
+BinPackParameters: BinPack
+
+# Allman style - opening brace on new line
 BraceWrapping:
   AfterCaseLabel: true
   AfterClass: true
@@ -36,62 +49,84 @@ BraceWrapping:
   AfterExternBlock: true
   BeforeCatch: true
   BeforeElse: true
-  IndentBraces: false
+  BeforeLambdaBody: true
+  BeforeWhile: true
+  IndentBraces: true
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
+
 BreakBeforeBinaryOperators: NonAssignment
-BreakBeforeBraces: Custom
+BreakBeforeBraces: Allman
 BreakBeforeInheritanceComma: false
 BreakInheritanceList: BeforeColon
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeColon
-BreakAfterJavaFieldAnnotations: true
 BreakStringLiterals: true
-ColumnLimit: 80
+
+# Set to 0 to allow longer lines, or 80 for strict enforcement
+ColumnLimit: 0
+
 CommentPragmas: "^ IWYU pragma:"
 CompactNamespaces: false
+
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
+
+DeriveLineEnding: true
 DerivePointerAlignment: false
 DisableFormat: false
+
 ExperimentalAutoDetectBinPacking: false
-FixNamespaceComments: true
+FixNamespaceComments: false
+
+# OpenFOAM loop macros
 ForEachMacros:
-  - foreach
-  - Q_FOREACH
-  - BOOST_FOREACH
-IncludeBlocks: Regroup
+  - forAllIters
+  - forAllConstIters
+  - forAllReverseIters
+  - forAllConstReverseIters
+  - forAll
+  - forAllReverse
+  - forAllIter
+  - forAllConstIter
+
+IncludeBlocks: Preserve
 IncludeCategories:
-  - Regex: "^<cassert>"
-    Priority: 1
-  - Regex: "^<cstdlib>"
-    Priority: 1
-  - Regex: '^<.*\.h>'
+  - Regex: '^"(llvm|llvm-c|clang|clang-c)/'
     Priority: 2
-  - Regex: "^<[^/]*>"
+  - Regex: '^(<|"(gtest|gmock|isl|json)/)'
     Priority: 3
   - Regex: ".*"
-    Priority: 4
+    Priority: 1
+
 IncludeIsMainRegex: "(Test)?$"
+IncludeIsMainSourceRegex: ""
+
 IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
 IndentPPDirectives: None
 IndentWidth: 4
 IndentWrappedFunctionNames: false
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
+
+InsertTrailingCommas: None
 KeepEmptyLinesAtTheStartOfBlocks: true
+
 MacroBlockBegin: ""
 MacroBlockEnd: ""
-MaxEmptyLinesToKeep: 1
+MaxEmptyLinesToKeep: 2
+
 NamespaceIndentation: None
+
 ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 4
 ObjCSpaceAfterProperty: true
 ObjCSpaceBeforeProtocolList: true
+
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
@@ -100,10 +135,11 @@ PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
+
 PointerAlignment: Left
-ReflowComments: Always
-SortIncludes: { Enabled: false }
+ReflowComments: Never
 SortUsingDeclarations: Never
+
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: false
@@ -113,6 +149,7 @@ SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
+
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles: Never
@@ -120,11 +157,12 @@ SpacesInContainerLiterals: false
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
+
 Standard: c++11
+
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
-  - FOAM_UNLIKELY
-  - FOAM_LIKELY
+
 TabWidth: 4
 UseTab: Never

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,130 @@
+Language: Cpp
+# BasedOnStyle:  WebKit
+# Adjusted for OpenFOAM coding standards
+AccessModifierOffset: -4
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Right
+AlignOperands: DontAlign
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: false
+BinPackParameters: OnePerLine
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: true
+BreakStringLiterals: true
+ColumnLimit: 80
+CommentPragmas: "^ IWYU pragma:"
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: "^<cassert>"
+    Priority: 1
+  - Regex: "^<cstdlib>"
+    Priority: 1
+  - Regex: '^<.*\.h>'
+    Priority: 2
+  - Regex: "^<[^/]*>"
+    Priority: 3
+  - Regex: ".*"
+    Priority: 4
+IncludeIsMainRegex: "(Test)?$"
+IndentCaseLabels: false
+IndentPPDirectives: None
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ""
+MacroBlockEnd: ""
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments: Always
+SortIncludes: { Enabled: false }
+SortUsingDeclarations: Never
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: Never
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: c++11
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+  - FOAM_UNLIKELY
+  - FOAM_LIKELY
+TabWidth: 4
+UseTab: Never

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+<!-- One or two sentences: what does this PR change? -->
+
+## Why
+<!-- Motivation: what symptom, missing capability, or bug does this address?
+     For refactors: what made the previous structure painful. Skip if the
+     diff is obviously self-justifying (e.g. typo fix). -->
+
+## Verification
+<!-- What did you actually run or check? Be specific.
+     Examples:
+     - Built with `./Allwmake` (or affected sub-target).
+     - Tutorial(s) re-run: `tutorials/cases/<name>` — residuals look normal.
+     - Regression suite: pass / N/A / baseline not yet captured.
+     - Notes on numerical impact (if any).
+     Skip if the change cannot affect runtime behaviour (e.g. README only). -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,19 @@ Also flag if the *Last verified* date below predates significant recent commits 
 
 Humans are welcome to edit this file, especially to record **current dev status** (what's stable, what's in flux, what direction the next chunk of work is heading). That section lives at the bottom.
 
+## Documentation source of truth
+
+Physics, equations, units, and algorithm choices belong in source-code comments — OpenFOAM-style `Description` block in the file banner, `//-` briefs above function declarations, `// ...` narrative inside the implementing function. README Part II is a *tour* that points into the code; it does **not** restate equations or implementation detail.
+
+In practice this means:
+
+- When a user asks to "document the physics" of a piece of code, write the comment in the source file (or expand an existing block). Update Part II only if the high-level flow changes.
+- When reading code to answer a physics question, quote the relevant comment block rather than re-deriving from the README. The code (and its comments) is authoritative.
+- If you see Part II restating something the code already comments on, replace it with a pointer to the source location — don't keep the duplication "just in case".
+- The migration from README-as-source-of-truth to code-as-source-of-truth is opportunistic: add comments to files as you touch them on other work, not in dedicated cleanup PRs.
+
+The full human-facing version of this rule is in README → Development Workflow → Documentation.
+
 ## Git / VCS rules
 
 - **Do not modify `git config --global`.** Pass identity per-invocation when needed: `git -c user.name="…" -c user.email="…" commit -m "…"`.

--- a/README.md
+++ b/README.md
@@ -36,13 +36,11 @@ Reported and plausible application areas include:
 9. [Regression Testing](#regression-testing)
 10. [Troubleshooting](#troubleshooting)
 
-**Part II — Physics and Code Structure**
+**Part II — Physics and Implementation**
 
 11. [Two-Phase Coexistence](#two-phase-coexistence)
-12. [Per-Time-Step Sequence](#per-time-step-sequence)
-13. [Solid Chemistry — ODE Integration](#solid-chemistry--ode-integration)
-14. [Porosity Evolution and Bed Motion](#porosity-evolution-and-bed-motion)
-15. [Gas-Solid Coupling](#gas-solid-coupling)
+12. [Per-Time-Step Tour](#per-time-step-tour)
+13. [Where to Look for What](#where-to-look-for-what)
 
 [Development Workflow](#development-workflow) · [Citation](#citation) · [Contributors](#contributors)
 
@@ -522,267 +520,37 @@ Defaults: `rtol=1e-4`, `atol=1e-12`. Both can be overridden per-run. The header 
 
 ---
 
-## Part II — Physics and Code Structure
+## Part II — Physics and Implementation
 
-*How the solver works. Useful when porting cases, extending models, or interpreting unexpected results.*
+*A tour, not a reference. Equations, units, and algorithm choices live in the source files that implement them — `Description` blocks in the file banner, block comments above the relevant function, and inline narrative inside. This section narrates the flow and points at where to look.*
 
 ## Two-Phase Coexistence
 
-Gas and solid phases coexist in every cell, distinguished by the **porosity** field `porosityF`:
+Gas and solid coexist in every cell, distinguished by the porosity field `porosityF` ∈ [0, 1]: 1.0 is pure gas, 0.0 is pure solid, in-between is a porous medium containing both phases. Solid bulk density is `rhos = rho · (1 − porosityF)`, where `rho` is the intrinsic solid material density. Mass, momentum, and energy are exchanged between phases via coupling source terms computed by the pyrolysis/chemistry model.
 
-| `porosityF` | Meaning |
+## Per-Time-Step Tour
+
+The main loop is in `porousGasificationFoam/porousGasificationFoam.C`. Each piece of work is pulled in via an `#include`, so the file reads top-to-bottom as a sequence. The steps below cite the include or function that does the work:
+
+1. **Time-step control** — Courant (gas), diffusion (solid), and chemistry timescale are combined into one stable `deltaT`. See `setMultiRegionDeltaT.H` and `updateChemistryTimeStep.H`.
+2. **DEM coupling** (compiled only when `WITH_YADE` is defined) — particle positions and velocities are exchanged with YADE, then the interpolated solid-velocity field is computed (raw per-cell average, then Laplace-smoothed into adjacent solid cells). See `lambdaDotModel::update()` in `porousGasificationMedia/DEM/lambdaDotModel.C`.
+3. **Radiation** — heterogeneous radiation model (`heterogeneousP1` or `heterogeneousMeanTemp`) updates the solid radiative source term. See `porousGasificationFoam/radiation.H` and `porousGasificationMedia/radiationModels/`.
+4. **Solid phase evolution** — the heart of the solver: per-cell chemistry ODE, solid species mass conservation, porosity evolution (with optional bed-collapse), and the solid energy equation. See `volPyrolysis::evolveRegion()` in `porousGasificationMedia/pyrolysisModels/pyrolysisModel/volPyrolysis/volPyrolysis.C`.
+5. **Gas continuity** — gas-phase density update with the solid-to-gas mass source. See `porousGasificationFoam/rhoEqn.H`.
+6. **PIMPLE loop** — momentum (`UEqn.H`) with Darcy/Forchheimer porous resistance, gas species (`YEqn.H`), gas energy (`EEqn.H`), and pressure correction (`pEqn.H` or `pcEqn.H` depending on `pimple.consistent()`).
+7. **Turbulence correction** — `turbulence->correct()` in the main loop.
+
+## Where to Look for What
+
+| Question | Where to look |
 |---|---|
-| 1.0 | Pure gas (no solid) |
-| 0.0 | Pure solid (fully dense) |
-| 0 < `porosityF` < 1 | Porous medium containing both phases |
-
-The solid mass per unit volume is `rhos = rho * (1 - porosityF)` [kg/m³], where `rho` is the intrinsic solid material density. Mass, momentum, and energy are exchanged between phases through coupling source terms computed by the pyrolysis/chemistry model.
-
-## Per-Time-Step Sequence
-
-The main solver loop in `porousGasificationFoam.C` executes the following sequence each time step:
-
-```
-┌─────────────────────────────────────────────────┐
-│ 1. Time-step control                            │
-│    → Courant (gas), Diffusion (solid), Chemistry │
-├─────────────────────────────────────────────────┤
-│ 2. Radiation (solid phase)                      │
-│    → radiation->correct()                       │
-│    → radiationF = radiation->solidSh()          │
-├─────────────────────────────────────────────────┤
-│ 3. Solid phase evolution                        │
-│    → pyrolysisZone.evolve()                     │
-│      a. Chemistry ODE integration               │
-│      b. Solid species mass conservation         │
-│      c. Porosity evolution                      │
-│      d. Solid energy equation                   │
-├─────────────────────────────────────────────────┤
-│ 4. Gas continuity (rhoEqn)                      │
-│    → ∂(φ·ρ)/∂t + ∇·(φ·U) = Sρ·(1-φ)           │
-├─────────────────────────────────────────────────┤
-│ 5. PIMPLE loop (iterative):                     │
-│    a. Momentum (UEqn) — NS + Darcy (+Forchheimer)│
-│    b. Gas species (YEqn) — advection-diffusion  │
-│    c. Gas energy (EEqn) — enthalpy transport    │
-│    d. Pressure correction (pEqn)                │
-├─────────────────────────────────────────────────┤
-│ 6. Turbulence update                            │
-└─────────────────────────────────────────────────┘
-```
-
-### Step 1: Time-Step Control
-
-Three stability limits are checked and the minimum time step is selected:
-
-```
-maxDeltaTFluid  = maxCo / (CoNum + SMALL)
-maxDeltaTSolid  = maxDi / (DiNum + SMALL)
-```
-
-- `maxCo` — Courant number for the gas phase (default 5)
-- `maxDi` — Diffusion number for the solid phase (default 5000), computed from `K * deltaCoeffs / (Cp * rho)`
-- Chemistry time step — returned by the ODE integrator
-
-The actual time step change is damped to avoid oscillations:
-```
-dt_new = dt_old * min(1.2, min(1+0.1·r_fluid, 1+0.1·r_solid, r_fluid, r_solid))
-```
-
-### Step 2: Radiation
-
-```cpp
-radiation->correct();
-radiationF = radiation->solidSh();
-```
-
-Two heterogeneous radiation models:
-
-| Model | Description |
-|---|---|
-| `heterogeneousP1` | P1 approximation — accounts for solid-phase absorption, scattering, emission. Solves a diffusion equation for incident radiation. |
-| `heterogeneousMeanTemp` | Simplified model using mean temperature. |
-
-Radiative source term `radiationF` [W/m³] is computed based on solid temperature, absorption coefficient `a`, scattering coefficient `as`, and surface layer properties (`borderAs`, `borderL`).
-
-### Step 3: Solid Phase Evolution (`pyrolysisZone.evolve()`)
-
-This is the heart of the solver, implemented in `volPyrolysis::evolveRegion()` (`volPyrolysis.C:1214`). It performs five sub-steps:
-
-#### 3a. Solid Chemistry ODE Integration
-
-`solidChemistry_->solve(t0, deltaT)` integrates per-cell ODEs for solid species conversion, gas generation, and temperature change, and returns the characteristic chemical timescale. See [Solid Chemistry — ODE Integration](#solid-chemistry--ode-integration) below for details.
-
-#### 3b. Chemical Energy Source
-
-`chemistrySh_ = solidChemistry_->Sh()()` computes heterogeneous reaction heat [W/m³]. Two modes:
-- `solidReactionEnergyFromEnthalpy = true`: uses heats of formation `hf` of solid and gas species
-- `solidReactionEnergyFromEnthalpy = false`: uses specified `heatOfReaction` from reaction definition
-
-#### 3c. Energy to Heat Pyrolysis Gases
-
-`heatUpGas_ = heatUpGasCalc()()` heats (or cools) pyrolysis gases from solid temperature `Ts` to gas temperature `Tg`. Magnitude: `Sρ · Cp_gas · (Ts − Tg)`.
-
-#### 3d. Solid Species Mass Conservation (`solveSpeciesMass()`)
-
-Solves two equations:
-
-1. **Solid bulk density** (advection only):
-```
-∂ρ_s/∂t = -∇·(ρ_s · Us)
-```
-
-2. **Solid species mass fractions** (chemistry + advection):
-```
-∂(ρLoc · Y_s,i)/∂t = ω_s,i - ∇·(Us · ρLoc · Y_s,i)
-```
-where `ρLoc = max(ρ · (1-φ), SMALL)`.
-
-After solving all species, mass fractions are renormalized so they sum to 1.
-
-#### 3e. Porosity Evolution (`evolvePorosity()`)
-
-```
-∂φ/∂t = RRpor - ∇·(Us · φ)
-```
-where:
-```
-RRpor = -Σ(ω_s,i / ρ_s,i)    [1/s]
-```
-
-After solving, cells where porosity exceeds `criticalPorosity` (default 0.9999) are identified for the bed-collapse algorithm. If `bedCollapse` is enabled, material from downstream cells is shifted upward to replenish solid mass.
-
-#### 3f. Solid Energy Equation (`solveEnergy()`)
-
-```
-ρCp · ∂Ts/∂t = ∇·(K_eff · ∇(Ts)) + Sh_chem - Q_conv - Q_heatUpGas + Q_radiation
-```
-
-where:
-- `K_eff = K · (1-φ) · anisotropyK` — effective solid thermal conductivity
-- `Sh_chem` — reaction heat from chemistry
-- `Q_conv = h · SAV · (Ts - Tg)` — gas-solid convective exchange (from `heatTransferProperties`)
-- `Q_heatUpGas` — energy to heat pyrolysis gas
-- `Q_radiation` — from radiation model
-
-A simplified immersed boundary treatment zeroes out conductive fluxes across the gas-solid interface to avoid spurious heat transfer at porous medium boundaries.
-
-## Solid Chemistry — ODE Integration
-
-The chemistry model is `ODESolidHeterogeneousChemistryModel` in `thermophysicalModels/porousSolidChemistryModel/`.
-
-### Reaction Rate Laws
-
-Four kinetic rate variants (line 1 of reaction definition):
-
-| Keyword | Rate formula `k(T) =` |
-|---|---|
-| `irreversibleSolidArrheniusHeterogeneousReaction` | `A · exp(-Ta/T)` (if T ≥ Tcrit, else 0) |
-| `irreversibleSolidTemperatureArrheniusHeterogeneousReaction` | `A · T · exp(-Ta/T)` |
-| `irreversibleSolidModArrHeterogeneousReaction` | `A · (T-Tcrit)^(2/3) · exp(-Ta/T)` |
-| `irreversibleSolidConstHeterogeneousReaction` | `A` (constant) |
-
-The overall forward rate for a reaction is:
-
-```
-kf = k(T) · Π(Y_reactant_i^n_i) · ρ_solid   (for solid reactants)
-kf = k(T) · Π(Y_reactant_i^n_i) · ρ_gas     (for gas-only reactants)
-```
-
-### Diffusion-Limited Reactions
-
-When `diffusionLimitedReactions = true`, the effective rate is limited by mass transfer:
-
-```
-1/k_eff = 1/k_kinetic + Σ(1 / (ST · ρ_g · Y_gas_reactant))
-```
-
-where `ST` is the mass transfer coefficient [1/s] from `constant/specieTransferProperties`.
-
-### Per-Cell ODE System
-
-For each cell containing solid, the following system is solved:
-
-```
-d(ρ_s · Y_s,i)/dt = ω_s,i              (i = 1..nSolids)
-d(ρ_g · Y_g,j)/dt = ω_g,j              (j = 1..nGases)
-dT/dt = -Σ(ω_i · H_i) / Σ(Y_i · Cp_i)   (temperature)
-```
-
-The last equation is derived from the energy balance: reaction heat changes temperature via `Cp·dT/dt = -Σ(ω_i · hf_i)` when using enthalpy-based energy, or `Cp·dT/dt = heatOfReaction` when using specified heats.
-
-### ODE Sub-Cycling Algorithm (`calculateSourceTerms()`)
-
-Adaptive sub-cycling: each sub-step calls the ODE solver, returns the characteristic chemical timescale `tauC_`, advances temperature from the reaction enthalpy, then shrinks the next `dt_` to `min(timeLeft, tauC_)`. The default solver is `seulex` (implicit extrapolation), configured in `chemistryProperties`.
-
-### Mass Partitioning
-
-Two modes controlled by `stoichiometricReactions`:
-
-| Mode | Description |
-|---|---|
-| `false` (default) | Mass fractions split by stoichiometric coefficient ratios. Total substrates mass = total products mass. |
-| `true` | Uses molecular weights to compute mass-conserving partitioning. Accounts for differences in molar masses between reactants and products. |
-
-In both modes, mass is strictly conserved. If a solid substrate converts to both solid products and gas products, the mass ratio between solid and gas products is proportional to the stoichiometric coefficients.
-
-## Porosity Evolution and Bed Motion
-
-### Porosity Source
-
-The porosity source term represents solid consumption:
-
-```
-RRpor = -Σ(ω_s,i / ρ_s,i)
-```
-
-The porosity equation is solved with an advection term for moving beds:
-
-```cpp
-fvScalarMatrix porosityEqn
-(
-    fvm::ddt(por)
-    ==
-    porositySource_
-    - fvc::div(Us, por, "div(phiSolid)")
-);
-```
-
-### Bed Collapse Model
-
-When `bedCollapse = true` in `pyrolysisProperties` and porosity exceeds `criticalPorosity`:
-
-1. **Detection**: Cells where `porosity > criticalPorosity` AND `(Us · ∇(whereIs)) > 0` (solid moving into the cell) are flagged.
-2. **Path tracing**: Starting from each flagged cell, the algorithm follows the advection path opposite to the solid velocity direction, building a chain of cells (a "route").
-3. **Material shift**: Properties (porosity, porosityF0, temperature, solid density, solid species mass fractions) are copied from the source cell downward along the route:
-
-```cpp
-porosity[destination] = 1 - (1 - porosity[source]) * (V_source / V_destination)
-T[destination] = T[source]
-rho[destination] = rho[source]
-Ys[i][destination] = Ys[i][source]
-```
-
-## Gas-Solid Coupling
-
-Each conserved quantity has equal-and-opposite source terms in the solid and gas equations.
-
-| Quantity | Solid side | Gas side |
-|---|---|---|
-| Mass | `−ω_s` (loss) | `+ω_s` in continuity, species, pressure equations |
-| Species `i` | `−ω_s,i` | `+ω_s,i` in `YEqn` for the gas species |
-| Energy | `+Sh_chem − Q_conv − Q_heatUpGas + Q_rad` in `solveEnergy()` | `+Q_conv + Q_heatUpGas + radiation->Sh()` in `EEqn` |
-| Momentum | (no solid-side source) | `−Df·U` Darcy (+ optional Forchheimer) in `UEqn` |
-| Volume | occupies `(1 − porosityF)` | `porosityF` multiplies gas-phase volume terms |
-
-Term definitions:
-
-- `Sρ_total = Σ ω_s,i` [kg/m³/s] — total mass transferred solid→gas; in gas equations it is limited to `(1 − porosityF)`.
-- `Sρ(i) = ω_g,i` [kg/m³/s] — mass of gas species `i` produced by pyrolysis.
-- `Q_conv = h · SAV · (Ts − Tg)` [W/m³] — convective gas-solid heat exchange.
-- `Q_heatUpGas = Sρ · Cp_gas · (Ts − Tg)` [W/m³] — energy needed to heat pyrolysis products from `Ts` to `Tg`.
-- `Sh_chem` (`chemistrySh_`) [W/m³] — heterogeneous reaction heat.
-- `radiation->Sh()` [W/m³] — radiative source term, sign depending on local emission/absorption balance.
+| What equation does this step solve? Which terms, which units? | `Description` block in the file banner and the comment block above the relevant `evolve*` / `solve*` / `*Eqn` function in the corresponding `.C`/`.H`. |
+| Which input dictionary keys does X read? | Part I → [Input File Reference](#input-file-reference). |
+| What initial fields does a case need? | Part I → [Required Initial Fields](#required-initial-fields). |
+| Where does this field get constructed? | `porousGasificationFoam/createFields.H` for solver fields; `createDEMFields.H` for DEM-coupled fields. |
+| How does the solver layout map to OpenFOAM modules? | Part I → [Project Structure](#project-structure). |
+
+If you find a discrepancy between this tour and what the code does, the code wins — please open an issue or PR.
 
 ---
 
@@ -840,6 +608,20 @@ Opening a PR auto-populates the description from `.github/pull_request_template.
 - **Verification** — what you actually ran or checked: build target, tutorial cases, regression suite, residual sanity. Skip if the change cannot affect runtime (README only).
 
 Aim for terse and specific. The body becomes part of `main`'s history once squash-merged, so future-you (and `git log`) benefit from precision now.
+
+### Documentation
+
+Source code is the source of truth for physics, equations, units, and algorithm choices. Comments live next to the implementation they describe — OpenFOAM-style file banner with a `Description` block, `//-` briefs above function declarations, and `// ...` narrative inside function bodies for non-obvious steps.
+
+The README's [Part II](#part-ii--physics-and-implementation) is a tour: it narrates the per-step flow and points into the code. It does **not** restate equations or implementation detail — those belong in the source file that implements them, where they cannot drift unnoticed during refactors.
+
+When you submit a PR:
+
+- **Behaviour change** → update the relevant code-comment block in the same commit.
+- **Loop structure or step ordering change** → update Part II's per-step tour too.
+- **New documentation insight** → if it's about *what the code does*, write it as a code comment. If it's about *how to use* the solver or *how to navigate* the codebase, it belongs in the README.
+
+If you catch a Part II claim that's already in the code as a comment, replace it with a pointer in the same PR. The migration is opportunistic — no need to wait for a dedicated cleanup branch.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,29 @@
 # porousGasificationFoam
 
-*porousGasificationFoam* (PGF) is an OpenFOAM solver for **thermochemical conversion in porous media**. A solid phase, represented as a porosity field, is coupled to a gas flowing through the void space. Mass, momentum, and energy are exchanged through the porosity. All chemistry — gas-phase, heterogeneous (gas–solid), and solid decomposition — is defined per case. With no reactions defined, both phases stay inert. The solid can be stationary or move under gravity and other external forces, shrink, or disappear entirely as conversion proceeds.
+porousGasificationFoam (PGF) is an OpenFOAM solver for **thermochemical conversion in porous media**. A reactive solid phase, represented as a porosity field, is coupled to a compressible gas flowing through the void space; mass, momentum, and energy are exchanged through the porosity. The solid can be stationary or move under gravity and other external forces, shrink, or disappear entirely as conversion proceeds. Heterogeneous radiation, bed collapse, and DEM coupling for granular solids are optional.
 
-The continuum transport equations are solved with the Finite Volume Method (OpenFOAM). An optional coupling to a Discrete Element Method solver YADE provides PGF with a velocity field for the solid momentum equation. Solid material properties, initial distribution of porosity throughout a domain, reaction kinetics, and many other parameters — all these are user inputs — the solver is geometry- and chemistry-agnostic.
+The continuum transport equations are solved with the Finite Volume Method (OpenFOAM); an optional coupling to a Discrete Element Method solver via YADE handles the solid momentum equation when granular dynamics matter. Solid morphology, temperature, species, and reaction kinetics are user inputs — the solver is geometry- and chemistry-agnostic.
 
-Example application areas:
+Reported and plausible application areas include:
 
 - Biomass pyrolysis, gasification, and combustion (the solver's origin)
 - Wood fires and waste incineration
-- Coffee bean roasting
+- Coffee bean roasting and other slow thermal-conversion processes
 - Peat smouldering
-- Metal-foam manufacturing
+- Drying of moisture-laden porous beds
+- Sintering and metal-foam manufacturing
+- Dough rising and other expanding-bed processes
 
-…and other processes that share a reactive or transforming porous solid exchanging mass and heat with a gas. The name *porousGasificationFoam* reflects the solver's origins in biomass-to-syngas gasification (feedstock + air/O₂/steam/CO₂ → H₂/CO), not a limit on what it can model.
+…and other processes that share a reactive or transforming porous solid exchanging mass and heat with a gas. The name reflects the solver's origins in biomass-to-syngas gasification (feedstock + air/O₂/steam/CO₂ → H₂/CO), not a limit on what it can model.
 
 - **License**: GNU GPL v3
 - **Target**: OpenFOAM-v2406
 - **Optional**: DEM coupling via YADE (`WITH_YADE=1` at build time)
-- Earlier versions for [OpenFOAM 8](https://github.com/btuznik/porousGasificationFoam) and foam-extend 4.1 exist but are no longer actively maintained.
+- Earlier ports for [OpenFOAM 8](https://github.com/btuznik/porousGasificationFoam) and foam-extend 4.1 exist but are no longer actively maintained.
 
 ## Contents
+
+**Part I — Practical Guide**
 
 1. [Quick Start](#quick-start)
 2. [Project Structure](#project-structure)
@@ -32,7 +36,21 @@ Example application areas:
 9. [Regression Testing](#regression-testing)
 10. [Troubleshooting](#troubleshooting)
 
+**Part II — Physics and Code Structure**
+
+11. [Two-Phase Coexistence](#two-phase-coexistence)
+12. [Per-Time-Step Sequence](#per-time-step-sequence)
+13. [Solid Chemistry — ODE Integration](#solid-chemistry--ode-integration)
+14. [Porosity Evolution and Bed Motion](#porosity-evolution-and-bed-motion)
+15. [Gas-Solid Coupling](#gas-solid-coupling)
+
 [Citation](#citation) · [Contributors](#contributors)
+
+---
+
+## Part I — Practical Guide
+
+*Build, run, configure, debug. Most readers spend their time here.*
 
 ## Quick Start
 
@@ -40,70 +58,106 @@ Example application areas:
 
 - OpenFOAM-v2406
 - MPI (for parallel runs)
-- Optional: YADE DEM library (for DEM coupling — set `WITH_YADE=1`)
+- Optional: YADE DEM library (for DEM coupling; set `WITH_YADE=1`)
 
 ### Build and Install
 
 ```bash
-
-# 1. Source OpenFOAM (adjust paths for your installation)
+# 1. Source OpenFOAM (adjust path for your installation)
 source /path/to/OpenFOAM-v2406/etc/bashrc
 
-# 2. Build everything
+# 2. Set porousGasificationFoam environment variables
 cd /path/to/porousGasificationFoam
+source porousGasificationMediaDirectories
+
+# 3. Build everything
 ./Allwmake
 
-# 3. Test installation
+# Alternative: fine-grained build
+./build.sh build --all
+```
+
+### Run a Tutorial Case
+
+`charOnlyMove` is the lightest tutorial (moving char bed, no chemistry) and works well as a first smoke test once the build succeeds:
+
+```bash
 cd tutorials/cases/charOnlyMove
 ./Allrun
 ```
 
-For a full reactive-flow demonstration see `gasifier`. The complete list is under [Tutorial Cases](#tutorial-cases). To run every case: `cd tutorials && ./TestAllCases.sh`. To clean a build: `./Allwclean`.
+For a full reactive-flow demonstration see `gasifier` (4-proc parallel biomass gasifier). The complete list is under [Tutorial Cases](#tutorial-cases). To run every case in turn: `cd tutorials && ./TestAllCases.sh`. To clean a build: `./Allwclean` (or `./build.sh clean --all`).
 
 ## Project Structure
 
 ```
 porousGasificationFoam/
-├── porousGasificationFoam/    # main solver source (time loop, equations)
-├── porousGasificationMedia/   # libraries (pyrolysis, chemistry, radiation, DEM)
-├── tutorials/cases/           # tutorial cases (input examples)
-├── utilities/                 # auxiliary tools (setPorosity, totalMass, …)
-├── applications/test/         # regression framework
-├── build.sh                   # fine-grained build script
-└── doc/Doxygen/               # API documentation source
+├── porousGasificationFoam/          # Main solver executable
+│   ├── porousGasificationFoam.C     # Time loop (main algorithm)
+│   ├── createFields.H               # Field creation
+│   ├── createPorosity.H             # Darcy resistance setup
+│   ├── createPyrolysisModel.H       # Pyrolysis/solid chemistry setup
+│   ├── rhoEqn.H                     # Gas continuity equation
+│   ├── UEqn.H                       # Momentum equation (Navier-Stokes + Darcy)
+│   ├── YEqn.H                       # Gas species transport
+│   ├── EEqn.H                       # Gas energy equation
+│   ├── pEqn.H / pcEqn.H             # Pressure correction
+│   ├── radiation.H                  # Radiative source term
+│   ├── solidRegionDiffusionNo.H     # Solid diffusion stability
+│   ├── setMultiRegionDeltaT.H       # Time-step controller
+│   └── updateChemistryTimeStep.H    # Chemistry-limited time step
+├── porousGasificationMedia/         # Supporting libraries
+│   ├── pyrolysisModels/
+│   │   └── volPyrolysis/            # Solid-phase evolution engine
+│   ├── thermophysicalModels/
+│   │   └── porousSolidChemistryModel/
+│   │       ├── ODESolidHeterogeneousChemistryModel/  # ODE chemistry solver
+│   │       └── basicPorousChemistryModel/             # Base chemistry class
+│   ├── radiationModels/             # Heterogeneous P1 / mean-temp radiation
+│   ├── fieldPorosityModel/          # Darcy resistance (pZones.addResistance)
+│   └── DEM/                         # YADE DEM coupling (optional)
+├── tutorials/
+│   └── cases/                       # 13 tutorial cases
+├── utilities/
+│   ├── setPorosity/                 # Creates porosityF and Df fields
+│   ├── totalMassPorousGasificationFoam/  # Mass conservation diagnostic
+│   ├── bash_utils/                  # Helper scripts
+│   └── py_utils/                    # Python post-processing tools
+├── build.sh                         # Fine-grained build script
+└── doc/Doxygen/                     # Doxygen documentation source
 ```
 
 ## Build System
+
+### Simple build
+
+```bash
+./Allwmake      # Build everything
+./Allwclean     # Clean everything
+```
+
+### Fine-grained control with build.sh
+
+```bash
+./build.sh build --libs-only           # Libraries only
+./build.sh build --apps-only           # Solver and utilities only
+./build.sh build --radiationModels --pyrolysisModels --porousGasificationFoam  # Specific targets
+./build.sh build --no-DEM              # Skip DEM (if YADE not available)
+./build.sh build --all --dry-run       # Preview commands
+./build.sh clean --all                 # Clean all
+```
 
 ### Build targets
 
 | Target | Type | Dependency |
 |---|---|---|
-| DEM (if `WITH_YADE=1`)| library | —  |
+| DEM | library | — (if `WITH_YADE=1`) |
 | fieldPorosityModel | library | — |
 | radiationModels | library | solid thermo |
 | thermophysicalModels | library suite | — |
 | pyrolysisModels | library | all above |
 | porousGasificationFoam | executable | all libraries |
 | utilities | executable suite | — |
-
-### Fine-grained control with build.sh
-
-The `build.sh` script operates in two modes: `build` or `clean`. For the selected mode it builds or cleans all active targets. Targets are switched on or off via CLI flags.
-
-Examples:
-
-```bash
-./build.sh build --apps-only # set app targets to 1 and libs to 0, build targets with 1 set
-./build.sh clean --reset-all --radiationModels # set all targets to 0; set radiationModels to 1, clean only radiationModels (later flags overwrite previous ones)
-./build.sh build --all --no-DEM # skip DEM, build all the rest
-
-# Aliases
-./Allwmake  → ./build.sh build --all
-./Allwclean → ./build.sh clean --all
-```
-
-Run `build.sh --help` for all options.
 
 ### YADE DEM coupling
 
@@ -134,10 +188,10 @@ All 13 cases under `tutorials/cases/`:
 | `macroTGA_879K/` | Macro-scale TGA at 879 K | — |
 | `macroTGA_879K_fine/` | Macro-scale TGA at 879 K, refined mesh | — |
 | `macroTGA_experimentalData/` | TGA with experimental data comparison | — |
-| `gasifier/` | Fixed-bed gasifier | - |
+| `gasifier/` | Fixed-bed gasifier | 4-proc parallel, wedge geometry |
 | `flatPlate/` | Flat plate reactive flow | — |
 | `biomassPressureDrop/` | Pressure drop through biomass bed | — |
-| `charOnlyMove/` | Moving char (no reactions) | Solid material motion test |
+| `charOnlyMove/` | Moving char bed (no reactions) | Bed motion test |
 | `MicroTGA-DEM/` | DEM-coupled micro TGA | Requires YADE |
 | `DEM_UsInterp_*/` | DEM solid velocity interpolation tests | Requires YADE |
 
@@ -190,7 +244,7 @@ solidReactions
 | `A` | Pre-exponential factor | varies |
 | `Ta` | Activation temperature `Ea/R` | [K] |
 | `Tcrit` | Minimum temperature for reaction | [K] |
-| `heatOfReaction` | Heat released/absorbed (<0 = exothermic) | [J/kg] |
+| `heatOfReaction` | Heat released/absorbed (>0 = exothermic) | [J/kg] |
 | `n1, n2, ...` | Reaction order for each LHS species in order | — |
 
 ### `constant/solidThermophysicalProperties`
@@ -262,7 +316,7 @@ Parameters
 }
 ```
 
-nly used when `diffusionLimitedReactions true`.
+Only used when `diffusionLimitedReactions true`.
 
 ### `constant/porosityProperties` (optional)
 
@@ -272,7 +326,7 @@ Adds a Forchheimer (quadratic) resistance term to the momentum equation on top o
 forchheimerCoeff 3.21e6;
 ```
 
-Effective momentum sink: `−µ_eff · D · ⟨u⟩  −  F_c · ρ_f · |⟨u⟩| · √3 · D / |D|`. The Forchheimer term matters for high-velocity flow through coarse beds. For slow flow inside a fine porous medium the linear Darcy term is usually sufficient. Unlike `Df` (a per-cell field), `forchheimerCoeff` is a single scalar applied everywhere.
+Effective momentum sink: `−µ_eff · D · ⟨u⟩  −  F_c · ρ_f · |⟨u⟩| · √3 · D / |D|`. The Forchheimer term matters for high-velocity flow through coarse beds (≳ 1 m/s); for slow flow inside a fine porous medium the linear Darcy term is usually sufficient. Unlike `Df` (a per-cell field), `forchheimerCoeff` is a single scalar applied everywhere.
 
 ### `constant/radiationProperties`
 
@@ -315,7 +369,7 @@ The `Ts` (solid temperature) solver requires a tight tolerance (1e-10) for stabi
 ### `system/fvSchemes` — Key Settings
 
 ```cpp
-div(phiSolid)     Gauss upwind;
+div(phiSolid)     Gauss upwind;   // MUST be upwind for solid advection stability
 ```
 
 ### `system/controlDict` — Key Settings
@@ -346,7 +400,6 @@ maxDi           5000;       // Diffusion number limit (solid)
 | `YsDefault` | volScalarField | Default field for unmatched solid species (set to 0) |
 
 **Notes:**
-
 - `Df` is a tensor field. For isotropic porous media, use a diagonal tensor with large values (e.g. `1e9`) in gas-only regions and smaller values (based on permeability) in porous zones. Use the `setPorosity` utility to create appropriate fields.
 - Solid species field names: `Y` + component name from `solidThermophysicalProperties` (e.g. `wood` → `Ywood`).
 - Gas species field names match the `species` list in `chemistryProperties`.
@@ -359,13 +412,13 @@ Practical notes that are easy to get wrong on a first PGF case.
 
 Three approaches, in increasing order of complexity:
 
-1. **`setFields`** (with or without `setSet`): the standard OpenFOAM workflow. Specify a `setFieldsDict` that sets `porosityF` inside a cell zone to the desired void fraction and leaves the rest at `1.0`. `setFields` alone is sufficient for simple geometries. Pair with `setSet` (batch mode) for more involved selection logic. Other fields (`T`, `Ts`, solid species mass fractions, …) can be initialised the same way. See `tutorials/cases/macroTGA_*` for an example chain (`blockMesh` → `setSet` → `refineHexMesh` → `setFields`).
+1. **`setFields`** (with or without `setSet`): the standard OpenFOAM workflow. Specify a `setFieldsDict` that sets `porosityF` inside a cell zone to the desired void fraction and leaves the rest at `1.0`. `setFields` alone is sufficient for simple geometries; pair with `setSet` (batch mode) for more involved selection logic. Other fields (`T`, `Ts`, solid species mass fractions, …) can be initialised the same way. See `tutorials/cases/macroTGA_*` for an example chain (`blockMesh` → `setSet` → `refineHexMesh` → `setFields`).
 2. **STL + `setFields`**: for non-trivial bed geometries, build an STL of the porous region in Salome or Blender and feed it to `setSet`/`setFields` via a `surfaceToCell` selector.
-3. **`setPorosity` utility** *(possibly outdated)*: a code-driven generator (see `utilities/setPorosity/`). The user-editable description of the medium lives in `medium.H` — the tool must be recompiled after each change. Kept for backward compatibility with older cases and parametric sweeps. For new cases, prefer approaches 1 and 2 above.
+3. **`setPorosity` utility**: a code-driven generator (see `utilities/setPorosity/`). The user-editable description of the medium lives in `medium.H`; the tool must be recompiled after each change. Recommended only when scripted parametric sweeps are needed.
 
 ### Solid thermophysical properties: true density, not bulk
 
-Entries in `solidThermophysicalProperties` (`rho`, `K`, `Cp`, `Hf`) describe the **pure solid** — i.e. the material at `porosityF = 0`. The macroscopic bulk density inside the bed is then `ρ · (1 − φ)`. PGF reconstructs it from `porosityF` and the intrinsic `rho`. Literature often reports bulk values instead, so be careful: feeding a bulk density into `rho` understates the solid by a factor of `(1 − φ)`.
+Entries in `solidThermophysicalProperties` (`rho`, `K`, `Cp`, `Hf`) describe the **pure solid** — i.e. the material at `porosityF = 0`. The macroscopic bulk density inside the bed is then `ρ · (1 − φ)`; PGF reconstructs it from `porosityF` and the intrinsic `rho`. Literature often reports bulk values instead, so be careful: feeding a bulk density into `rho` understates the solid by a factor of `(1 − φ)`. The exception is the `gasifier` tutorial, which deliberately models the entire packed bed at the megascopic scale using bulk wood density (`rho 663` kg/m³ vs ≈ 1050 kg/m³ for true wood); this is a modelling choice consistent with treating the bed as a homogeneous Darcy medium.
 
 ### Gas species without JANAF data
 
@@ -373,26 +426,26 @@ Pyrolysis pseudo-species (e.g. lumped `tar`, `targas`) generally have no JANAF c
 
 ### Radiation parameters are the hardest to source
 
-The heterogeneous radiation coefficients (`a`, `as`, `borderAs`, `borderL`, `E`) rarely appear in literature with the right semantics. A workable approach is to tune them on a small TGA-like case so that the simulated heating rate matches an experiment, then reuse the tuned values across geometries that share the same surface chemistry and pellet morphology.
+The heterogeneous radiation coefficients (`a`, `as`, `borderAs`, `borderL`, `E`) rarely appear in literature with the right semantics. The recommended workflow is to tune them on a small TGA-like case so that the simulated heating rate matches an experiment, then reuse the tuned values across geometries that share the same surface chemistry and pellet morphology. The macroTGA tutorials are sized for exactly this calibration step.
 
 ### Time-step coupling between gas and solid chemistry
 
 Gas-phase reactions are typically orders of magnitude faster than heterogeneous solid reactions. When both are active, gas chemistry dominates the chemistry-limited time step and can make slow processes (e.g. gasification of a whole bed) very expensive. Practical implications:
 
 - For slow heterogeneous processes, prefer chemistry mechanisms with the minimum gas-phase detail needed for the result you care about.
-- `maxCo`, `maxDi`, and `initialChemicalTimeStep` in `controlDict` / `chemistryProperties` interact — tightening any one of them can mask the actual bottleneck. Check the solver log for which limit is binding before tuning.
+- `maxCo`, `maxDi`, and `initialChemicalTimeStep` in `controlDict` / `chemistryProperties` interact; tightening any one of them can mask the actual bottleneck. Check the solver log for which limit is binding before tuning.
 
 ### Mesh and parallel execution
 
-- Run `setPorosity` (if used) **before** `decomposePar` — it operates on the reconstructed mesh.
+- Run `setPorosity` (if used) **before** `decomposePar`; it operates on the reconstructed mesh.
 - The `totalMassPorousGasificationFoam` utility also requires a reconstructed case. Run `reconstructPar` first, or operate on the un-decomposed run.
 - `paraView -builtin` can visualise the decomposed processor directories directly without reconstruction — useful for very large cases.
-- Re-running a regression baseline must use the same `numberOfSubdomains` as the original — floating-point sensitivity to decomposition is real (see the "Regression Testing" section below).
+- Re-running a regression baseline must use the same `numberOfSubdomains` as the original; floating-point sensitivity to decomposition is real (see the "Regression Testing" section below).
 
 ## Utilities
 
-- **`setPorosity`** *(possibly outdated)* — generates `porosityF` and `Df` fields from medium parameters (particle diameter, tortuosity, permeability). Editable medium description in `utilities/setPorosity/medium.H`. Kept for backward compatibility — for new cases prefer the `setFields` + STL workflow (see [Tips](#biomass-distribution-initial-porosityf)).
-- **`totalMassPorousGasificationFoam`** — post-processing diagnostic that writes `totalMass.txt` (time, integrated solid mass `∫ρ_s · (1−porosityF) dV`) for the run. Operates on a reconstructed case — run `reconstructPar` first if the case was decomposed.
+- **`setPorosity`** — generates `porosityF` and `Df` fields from medium parameters (particle diameter, tortuosity, permeability). Run inside the case directory before the simulation; the editable medium description lives in `utilities/setPorosity/medium.H`.
+- **`totalMassPorousGasificationFoam`** — post-processing diagnostic that writes `totalMass.txt` (time, integrated solid mass `∫ρ_s · (1−porosityF) dV`) for the run. Operates on a reconstructed case; run `reconstructPar` first if the case was decomposed.
 
 ## Regression Testing
 
@@ -436,7 +489,7 @@ cd applications/test/regression
 ./Allrun --rtol 1e-3                    # override default relative tolerance
 ```
 
-Exit code 0 means all cases within tolerance — non-zero means at least one case failed. The script prints a per-case PASS/FAIL summary and, on failure, the rows that diverged.
+Exit code 0 means all cases within tolerance; non-zero means at least one case failed. The script prints a per-case PASS/FAIL summary and, on failure, the rows that diverged.
 
 ### What the comparison does
 
@@ -467,6 +520,272 @@ Defaults: `rtol=1e-4`, `atol=1e-12`. Both can be overridden per-run. The header 
 | Slow convergence in pressure | Tight PIMPLE settings | Increase `nCorrectors` or relax `p` tolerance |
 | Parallel: `decomposePar` fails | Missing decompose constraints | Ensure `Ts`, `porosityF`, `porosityF0` use `calculated` or `zeroGradient` BCs |
 
+---
+
+## Part II — Physics and Code Structure
+
+*How the solver works. Useful when porting cases, extending models, or interpreting unexpected results.*
+
+## Two-Phase Coexistence
+
+Gas and solid phases coexist in every cell, distinguished by the **porosity** field `porosityF`:
+
+| `porosityF` | Meaning |
+|---|---|
+| 1.0 | Pure gas (no solid) |
+| 0.0 | Pure solid (fully dense) |
+| 0 < `porosityF` < 1 | Porous medium containing both phases |
+
+The solid mass per unit volume is `rhos = rho * (1 - porosityF)` [kg/m³], where `rho` is the intrinsic solid material density. Mass, momentum, and energy are exchanged between phases through coupling source terms computed by the pyrolysis/chemistry model.
+
+## Per-Time-Step Sequence
+
+The main solver loop in `porousGasificationFoam.C` executes the following sequence each time step:
+
+```
+┌─────────────────────────────────────────────────┐
+│ 1. Time-step control                            │
+│    → Courant (gas), Diffusion (solid), Chemistry │
+├─────────────────────────────────────────────────┤
+│ 2. Radiation (solid phase)                      │
+│    → radiation->correct()                       │
+│    → radiationF = radiation->solidSh()          │
+├─────────────────────────────────────────────────┤
+│ 3. Solid phase evolution                        │
+│    → pyrolysisZone.evolve()                     │
+│      a. Chemistry ODE integration               │
+│      b. Solid species mass conservation         │
+│      c. Porosity evolution                      │
+│      d. Solid energy equation                   │
+├─────────────────────────────────────────────────┤
+│ 4. Gas continuity (rhoEqn)                      │
+│    → ∂(φ·ρ)/∂t + ∇·(φ·U) = Sρ·(1-φ)           │
+├─────────────────────────────────────────────────┤
+│ 5. PIMPLE loop (iterative):                     │
+│    a. Momentum (UEqn) — NS + Darcy (+Forchheimer)│
+│    b. Gas species (YEqn) — advection-diffusion  │
+│    c. Gas energy (EEqn) — enthalpy transport    │
+│    d. Pressure correction (pEqn)                │
+├─────────────────────────────────────────────────┤
+│ 6. Turbulence update                            │
+└─────────────────────────────────────────────────┘
+```
+
+### Step 1: Time-Step Control
+
+Three stability limits are checked and the minimum time step is selected:
+
+```
+maxDeltaTFluid  = maxCo / (CoNum + SMALL)
+maxDeltaTSolid  = maxDi / (DiNum + SMALL)
+```
+
+- `maxCo` — Courant number for the gas phase (default 5)
+- `maxDi` — Diffusion number for the solid phase (default 5000), computed from `K * deltaCoeffs / (Cp * rho)`
+- Chemistry time step — returned by the ODE integrator
+
+The actual time step change is damped to avoid oscillations:
+```
+dt_new = dt_old * min(1.2, min(1+0.1·r_fluid, 1+0.1·r_solid, r_fluid, r_solid))
+```
+
+### Step 2: Radiation
+
+```cpp
+radiation->correct();
+radiationF = radiation->solidSh();
+```
+
+Two heterogeneous radiation models:
+
+| Model | Description |
+|---|---|
+| `heterogeneousP1` | P1 approximation — accounts for solid-phase absorption, scattering, emission. Solves a diffusion equation for incident radiation. |
+| `heterogeneousMeanTemp` | Simplified model using mean temperature. |
+
+Radiative source term `radiationF` [W/m³] is computed based on solid temperature, absorption coefficient `a`, scattering coefficient `as`, and surface layer properties (`borderAs`, `borderL`).
+
+### Step 3: Solid Phase Evolution (`pyrolysisZone.evolve()`)
+
+This is the heart of the solver, implemented in `volPyrolysis::evolveRegion()` (`volPyrolysis.C:1214`). It performs five sub-steps:
+
+#### 3a. Solid Chemistry ODE Integration
+
+`solidChemistry_->solve(t0, deltaT)` integrates per-cell ODEs for solid species conversion, gas generation, and temperature change, and returns the characteristic chemical timescale. See [Solid Chemistry — ODE Integration](#solid-chemistry--ode-integration) below for details.
+
+#### 3b. Chemical Energy Source
+
+`chemistrySh_ = solidChemistry_->Sh()()` computes heterogeneous reaction heat [W/m³]. Two modes:
+- `solidReactionEnergyFromEnthalpy = true`: uses heats of formation `hf` of solid and gas species
+- `solidReactionEnergyFromEnthalpy = false`: uses specified `heatOfReaction` from reaction definition
+
+#### 3c. Energy to Heat Pyrolysis Gases
+
+`heatUpGas_ = heatUpGasCalc()()` heats (or cools) pyrolysis gases from solid temperature `Ts` to gas temperature `Tg`. Magnitude: `Sρ · Cp_gas · (Ts − Tg)`.
+
+#### 3d. Solid Species Mass Conservation (`solveSpeciesMass()`)
+
+Solves two equations:
+
+1. **Solid bulk density** (advection only):
+```
+∂ρ_s/∂t = -∇·(ρ_s · Us)
+```
+
+2. **Solid species mass fractions** (chemistry + advection):
+```
+∂(ρLoc · Y_s,i)/∂t = ω_s,i - ∇·(Us · ρLoc · Y_s,i)
+```
+where `ρLoc = max(ρ · (1-φ), SMALL)`.
+
+After solving all species, mass fractions are renormalized so they sum to 1.
+
+#### 3e. Porosity Evolution (`evolvePorosity()`)
+
+```
+∂φ/∂t = RRpor - ∇·(Us · φ)
+```
+where:
+```
+RRpor = -Σ(ω_s,i / ρ_s,i)    [1/s]
+```
+
+After solving, cells where porosity exceeds `criticalPorosity` (default 0.9999) are identified for the bed-collapse algorithm. If `bedCollapse` is enabled, material from downstream cells is shifted upward to replenish solid mass.
+
+#### 3f. Solid Energy Equation (`solveEnergy()`)
+
+```
+ρCp · ∂Ts/∂t = ∇·(K_eff · ∇(Ts)) + Sh_chem - Q_conv - Q_heatUpGas + Q_radiation
+```
+
+where:
+- `K_eff = K · (1-φ) · anisotropyK` — effective solid thermal conductivity
+- `Sh_chem` — reaction heat from chemistry
+- `Q_conv = h · SAV · (Ts - Tg)` — gas-solid convective exchange (from `heatTransferProperties`)
+- `Q_heatUpGas` — energy to heat pyrolysis gas
+- `Q_radiation` — from radiation model
+
+A simplified immersed boundary treatment zeroes out conductive fluxes across the gas-solid interface to avoid spurious heat transfer at porous medium boundaries.
+
+## Solid Chemistry — ODE Integration
+
+The chemistry model is `ODESolidHeterogeneousChemistryModel` in `thermophysicalModels/porousSolidChemistryModel/`.
+
+### Reaction Rate Laws
+
+Four kinetic rate variants (line 1 of reaction definition):
+
+| Keyword | Rate formula `k(T) =` |
+|---|---|
+| `irreversibleSolidArrheniusHeterogeneousReaction` | `A · exp(-Ta/T)` (if T ≥ Tcrit, else 0) |
+| `irreversibleSolidTemperatureArrheniusHeterogeneousReaction` | `A · T · exp(-Ta/T)` |
+| `irreversibleSolidModArrHeterogeneousReaction` | `A · (T-Tcrit)^(2/3) · exp(-Ta/T)` |
+| `irreversibleSolidConstHeterogeneousReaction` | `A` (constant) |
+
+The overall forward rate for a reaction is:
+
+```
+kf = k(T) · Π(Y_reactant_i^n_i) · ρ_solid   (for solid reactants)
+kf = k(T) · Π(Y_reactant_i^n_i) · ρ_gas     (for gas-only reactants)
+```
+
+### Diffusion-Limited Reactions
+
+When `diffusionLimitedReactions = true`, the effective rate is limited by mass transfer:
+
+```
+1/k_eff = 1/k_kinetic + Σ(1 / (ST · ρ_g · Y_gas_reactant))
+```
+
+where `ST` is the mass transfer coefficient [1/s] from `constant/specieTransferProperties`.
+
+### Per-Cell ODE System
+
+For each cell containing solid, the following system is solved:
+
+```
+d(ρ_s · Y_s,i)/dt = ω_s,i              (i = 1..nSolids)
+d(ρ_g · Y_g,j)/dt = ω_g,j              (j = 1..nGases)
+dT/dt = -Σ(ω_i · H_i) / Σ(Y_i · Cp_i)   (temperature)
+```
+
+The last equation is derived from the energy balance: reaction heat changes temperature via `Cp·dT/dt = -Σ(ω_i · hf_i)` when using enthalpy-based energy, or `Cp·dT/dt = heatOfReaction` when using specified heats.
+
+### ODE Sub-Cycling Algorithm (`calculateSourceTerms()`)
+
+Adaptive sub-cycling: each sub-step calls the ODE solver, returns the characteristic chemical timescale `tauC_`, advances temperature from the reaction enthalpy, then shrinks the next `dt_` to `min(timeLeft, tauC_)`. The default solver is `seulex` (implicit extrapolation), configured in `chemistryProperties`.
+
+### Mass Partitioning
+
+Two modes controlled by `stoichiometricReactions`:
+
+| Mode | Description |
+|---|---|
+| `false` (default) | Mass fractions split by stoichiometric coefficient ratios. Total substrates mass = total products mass. |
+| `true` | Uses molecular weights to compute mass-conserving partitioning. Accounts for differences in molar masses between reactants and products. |
+
+In both modes, mass is strictly conserved. If a solid substrate converts to both solid products and gas products, the mass ratio between solid and gas products is proportional to the stoichiometric coefficients.
+
+## Porosity Evolution and Bed Motion
+
+### Porosity Source
+
+The porosity source term represents solid consumption:
+
+```
+RRpor = -Σ(ω_s,i / ρ_s,i)
+```
+
+The porosity equation is solved with an advection term for moving beds:
+
+```cpp
+fvScalarMatrix porosityEqn
+(
+    fvm::ddt(por)
+    ==
+    porositySource_
+    - fvc::div(Us, por, "div(phiSolid)")
+);
+```
+
+### Bed Collapse Model
+
+When `bedCollapse = true` in `pyrolysisProperties` and porosity exceeds `criticalPorosity`:
+
+1. **Detection**: Cells where `porosity > criticalPorosity` AND `(Us · ∇(whereIs)) > 0` (solid moving into the cell) are flagged.
+2. **Path tracing**: Starting from each flagged cell, the algorithm follows the advection path opposite to the solid velocity direction, building a chain of cells (a "route").
+3. **Material shift**: Properties (porosity, porosityF0, temperature, solid density, solid species mass fractions) are copied from the source cell downward along the route:
+
+```cpp
+porosity[destination] = 1 - (1 - porosity[source]) * (V_source / V_destination)
+T[destination] = T[source]
+rho[destination] = rho[source]
+Ys[i][destination] = Ys[i][source]
+```
+
+## Gas-Solid Coupling
+
+Each conserved quantity has equal-and-opposite source terms in the solid and gas equations.
+
+| Quantity | Solid side | Gas side |
+|---|---|---|
+| Mass | `−ω_s` (loss) | `+ω_s` in continuity, species, pressure equations |
+| Species `i` | `−ω_s,i` | `+ω_s,i` in `YEqn` for the gas species |
+| Energy | `+Sh_chem − Q_conv − Q_heatUpGas + Q_rad` in `solveEnergy()` | `+Q_conv + Q_heatUpGas + radiation->Sh()` in `EEqn` |
+| Momentum | (no solid-side source) | `−Df·U` Darcy (+ optional Forchheimer) in `UEqn` |
+| Volume | occupies `(1 − porosityF)` | `porosityF` multiplies gas-phase volume terms |
+
+Term definitions:
+
+- `Sρ_total = Σ ω_s,i` [kg/m³/s] — total mass transferred solid→gas; in gas equations it is limited to `(1 − porosityF)`.
+- `Sρ(i) = ω_g,i` [kg/m³/s] — mass of gas species `i` produced by pyrolysis.
+- `Q_conv = h · SAV · (Ts − Tg)` [W/m³] — convective gas-solid heat exchange.
+- `Q_heatUpGas = Sρ · Cp_gas · (Ts − Tg)` [W/m³] — energy needed to heat pyrolysis products from `Ts` to `Tg`.
+- `Sh_chem` (`chemistrySh_`) [W/m³] — heterogeneous reaction heat.
+- `radiation->Sh()` [W/m³] — radiative source term, sign depending on local emission/absorption balance.
+
+---
+
 ## Citation
 
 If you use this solver, please cite:
@@ -475,7 +794,7 @@ If you use this solver, please cite:
 
 ## Contributors
 
-Paweł Jan Żuk, Bartosz Tużnik, Tadeusz Rymarz, Ali Ebrahimi Pure, Kamil Kwiatkowski, Marek Dudyński, Flavio C. C. Galeazzo, Guenther C. Krieger Filho, Filip Mróz (foam-extend-4.1 to v2406 port)
+Paweł Jan Żuk, Bartosz Tużnik, Tadeusz Rymarz, Zhiwar, Kamil Kwiatkowski, Marek Dudyński, Flavio C. C. Galeazzo, Guenther C. Krieger Filho, Filip Mróz (foam-extend-4.1 to v2406 port)
 
 ## For AI Coding Agents
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,23 @@
 # porousGasificationFoam
 
-porousGasificationFoam (PGF) is an OpenFOAM solver for **thermochemical conversion in porous media**. A reactive solid phase, represented as a porosity field, is coupled to a compressible gas flowing through the void space; mass, momentum, and energy are exchanged through the porosity. The solid can be stationary or move under gravity and other external forces, shrink, or disappear entirely as conversion proceeds. Heterogeneous radiation, bed collapse, and DEM coupling for granular solids are optional.
+*porousGasificationFoam* (PGF) is an OpenFOAM solver for **thermochemical conversion in porous media**. A solid phase, represented as a porosity field, is coupled to a gas flowing through the void space. Mass, momentum, and energy are exchanged through the porosity. All chemistry — gas-phase, heterogeneous (gas–solid), and solid decomposition — is defined per case. With no reactions defined, both phases stay inert. The solid can be stationary or move under gravity and other external forces, shrink, or disappear entirely as conversion proceeds.
 
-The continuum transport equations are solved with the Finite Volume Method (OpenFOAM); an optional coupling to a Discrete Element Method solver via YADE handles the solid momentum equation when granular dynamics matter. Solid morphology, temperature, species, and reaction kinetics are user inputs — the solver is geometry- and chemistry-agnostic.
+The continuum transport equations are solved with the Finite Volume Method (OpenFOAM). An optional coupling to a Discrete Element Method solver YADE provides PGF with a velocity field for the solid momentum equation. Solid material properties, initial distribution of porosity throughout a domain, reaction kinetics, and many other parameters — all these are user inputs — the solver is geometry- and chemistry-agnostic.
 
-Reported and plausible application areas include:
+Example application areas:
 
 - Biomass pyrolysis, gasification, and combustion (the solver's origin)
 - Wood fires and waste incineration
-- Coffee bean roasting and other slow thermal-conversion processes
+- Coffee bean roasting
 - Peat smouldering
-- Drying of moisture-laden porous beds
-- Sintering and metal-foam manufacturing
-- Dough rising and other expanding-bed processes
+- Metal-foam manufacturing
 
-…and other processes that share a reactive or transforming porous solid exchanging mass and heat with a gas. The name reflects the solver's origins in biomass-to-syngas gasification (feedstock + air/O₂/steam/CO₂ → H₂/CO), not a limit on what it can model.
+…and other processes that share a reactive or transforming porous solid exchanging mass and heat with a gas. The name *porousGasificationFoam* reflects the solver's origins in biomass-to-syngas gasification (feedstock + air/O₂/steam/CO₂ → H₂/CO), not a limit on what it can model.
 
 - **License**: GNU GPL v3
 - **Target**: OpenFOAM-v2406
 - **Optional**: DEM coupling via YADE (`WITH_YADE=1` at build time)
-- Earlier ports for [OpenFOAM 8](https://github.com/btuznik/porousGasificationFoam) and foam-extend 4.1 exist but are no longer actively maintained.
+- Earlier versions for [OpenFOAM 8](https://github.com/btuznik/porousGasificationFoam) and foam-extend 4.1 exist but are no longer actively maintained.
 
 ## Contents
 
@@ -56,106 +54,70 @@ Reported and plausible application areas include:
 
 - OpenFOAM-v2406
 - MPI (for parallel runs)
-- Optional: YADE DEM library (for DEM coupling; set `WITH_YADE=1`)
+- Optional: YADE DEM library (for DEM coupling — set `WITH_YADE=1`)
 
 ### Build and Install
 
 ```bash
-# 1. Source OpenFOAM (adjust path for your installation)
+
+# 1. Source OpenFOAM (adjust paths for your installation)
 source /path/to/OpenFOAM-v2406/etc/bashrc
 
-# 2. Set porousGasificationFoam environment variables
+# 2. Build everything
 cd /path/to/porousGasificationFoam
-source porousGasificationMediaDirectories
-
-# 3. Build everything
 ./Allwmake
 
-# Alternative: fine-grained build
-./build.sh build --all
-```
-
-### Run a Tutorial Case
-
-`charOnlyMove` is the lightest tutorial (moving char bed, no chemistry) and works well as a first smoke test once the build succeeds:
-
-```bash
+# 3. Test installation
 cd tutorials/cases/charOnlyMove
 ./Allrun
 ```
 
-For a full reactive-flow demonstration see `gasifier` (4-proc parallel biomass gasifier). The complete list is under [Tutorial Cases](#tutorial-cases). To run every case in turn: `cd tutorials && ./TestAllCases.sh`. To clean a build: `./Allwclean` (or `./build.sh clean --all`).
+For a full reactive-flow demonstration see `gasifier`. The complete list is under [Tutorial Cases](#tutorial-cases). To run every case: `cd tutorials && ./TestAllCases.sh`. To clean a build: `./Allwclean`.
 
 ## Project Structure
 
 ```
 porousGasificationFoam/
-├── porousGasificationFoam/          # Main solver executable
-│   ├── porousGasificationFoam.C     # Time loop (main algorithm)
-│   ├── createFields.H               # Field creation
-│   ├── createPorosity.H             # Darcy resistance setup
-│   ├── createPyrolysisModel.H       # Pyrolysis/solid chemistry setup
-│   ├── rhoEqn.H                     # Gas continuity equation
-│   ├── UEqn.H                       # Momentum equation (Navier-Stokes + Darcy)
-│   ├── YEqn.H                       # Gas species transport
-│   ├── EEqn.H                       # Gas energy equation
-│   ├── pEqn.H / pcEqn.H             # Pressure correction
-│   ├── radiation.H                  # Radiative source term
-│   ├── solidRegionDiffusionNo.H     # Solid diffusion stability
-│   ├── setMultiRegionDeltaT.H       # Time-step controller
-│   └── updateChemistryTimeStep.H    # Chemistry-limited time step
-├── porousGasificationMedia/         # Supporting libraries
-│   ├── pyrolysisModels/
-│   │   └── volPyrolysis/            # Solid-phase evolution engine
-│   ├── thermophysicalModels/
-│   │   └── porousSolidChemistryModel/
-│   │       ├── ODESolidHeterogeneousChemistryModel/  # ODE chemistry solver
-│   │       └── basicPorousChemistryModel/             # Base chemistry class
-│   ├── radiationModels/             # Heterogeneous P1 / mean-temp radiation
-│   ├── fieldPorosityModel/          # Darcy resistance (pZones.addResistance)
-│   └── DEM/                         # YADE DEM coupling (optional)
-├── tutorials/
-│   └── cases/                       # 13 tutorial cases
-├── utilities/
-│   ├── setPorosity/                 # Creates porosityF and Df fields
-│   ├── totalMassPorousGasificationFoam/  # Mass conservation diagnostic
-│   ├── bash_utils/                  # Helper scripts
-│   └── py_utils/                    # Python post-processing tools
-├── build.sh                         # Fine-grained build script
-└── doc/Doxygen/                     # Doxygen documentation source
+├── porousGasificationFoam/    # main solver source (time loop, equations)
+├── porousGasificationMedia/   # libraries (pyrolysis, chemistry, radiation, DEM)
+├── tutorials/cases/           # tutorial cases (input examples)
+├── utilities/                 # auxiliary tools (setPorosity, totalMass, …)
+├── applications/test/         # regression framework
+├── build.sh                   # fine-grained build script
+└── doc/Doxygen/               # API documentation source
 ```
 
 ## Build System
-
-### Simple build
-
-```bash
-./Allwmake      # Build everything
-./Allwclean     # Clean everything
-```
-
-### Fine-grained control with build.sh
-
-```bash
-./build.sh build --libs-only           # Libraries only
-./build.sh build --apps-only           # Solver and utilities only
-./build.sh build --radiationModels --pyrolysisModels --porousGasificationFoam  # Specific targets
-./build.sh build --no-DEM              # Skip DEM (if YADE not available)
-./build.sh build --all --dry-run       # Preview commands
-./build.sh clean --all                 # Clean all
-```
 
 ### Build targets
 
 | Target | Type | Dependency |
 |---|---|---|
-| DEM | library | — (if `WITH_YADE=1`) |
+| DEM (if `WITH_YADE=1`)| library | —  |
 | fieldPorosityModel | library | — |
 | radiationModels | library | solid thermo |
 | thermophysicalModels | library suite | — |
 | pyrolysisModels | library | all above |
 | porousGasificationFoam | executable | all libraries |
 | utilities | executable suite | — |
+
+### Fine-grained control with build.sh
+
+The `build.sh` script operates in two modes: `build` or `clean`. For the selected mode it builds or cleans all active targets. Targets are switched on or off via CLI flags.
+
+Examples:
+
+```bash
+./build.sh build --apps-only # set app targets to 1 and libs to 0, build targets with 1 set
+./build.sh clean --reset-all --radiationModels # set all targets to 0; set radiationModels to 1, clean only radiationModels (later flags overwrite previous ones)
+./build.sh build --all --no-DEM # skip DEM, build all the rest
+
+# Aliases
+./Allwmake  → ./build.sh build --all
+./Allwclean → ./build.sh clean --all
+```
+
+Run `build.sh --help` for all options.
 
 ### YADE DEM coupling
 
@@ -186,10 +148,10 @@ All 13 cases under `tutorials/cases/`:
 | `macroTGA_879K/` | Macro-scale TGA at 879 K | — |
 | `macroTGA_879K_fine/` | Macro-scale TGA at 879 K, refined mesh | — |
 | `macroTGA_experimentalData/` | TGA with experimental data comparison | — |
-| `gasifier/` | Fixed-bed gasifier | 4-proc parallel, wedge geometry |
+| `gasifier/` | Fixed-bed gasifier | - |
 | `flatPlate/` | Flat plate reactive flow | — |
 | `biomassPressureDrop/` | Pressure drop through biomass bed | — |
-| `charOnlyMove/` | Moving char bed (no reactions) | Bed motion test |
+| `charOnlyMove/` | Moving char (no reactions) | Solid material motion test |
 | `MicroTGA-DEM/` | DEM-coupled micro TGA | Requires YADE |
 | `DEM_UsInterp_*/` | DEM solid velocity interpolation tests | Requires YADE |
 
@@ -242,7 +204,7 @@ solidReactions
 | `A` | Pre-exponential factor | varies |
 | `Ta` | Activation temperature `Ea/R` | [K] |
 | `Tcrit` | Minimum temperature for reaction | [K] |
-| `heatOfReaction` | Heat released/absorbed (>0 = exothermic) | [J/kg] |
+| `heatOfReaction` | Heat released/absorbed (<0 = exothermic) | [J/kg] |
 | `n1, n2, ...` | Reaction order for each LHS species in order | — |
 
 ### `constant/solidThermophysicalProperties`
@@ -314,7 +276,7 @@ Parameters
 }
 ```
 
-Only used when `diffusionLimitedReactions true`.
+nly used when `diffusionLimitedReactions true`.
 
 ### `constant/porosityProperties` (optional)
 
@@ -324,7 +286,7 @@ Adds a Forchheimer (quadratic) resistance term to the momentum equation on top o
 forchheimerCoeff 3.21e6;
 ```
 
-Effective momentum sink: `−µ_eff · D · ⟨u⟩  −  F_c · ρ_f · |⟨u⟩| · √3 · D / |D|`. The Forchheimer term matters for high-velocity flow through coarse beds (≳ 1 m/s); for slow flow inside a fine porous medium the linear Darcy term is usually sufficient. Unlike `Df` (a per-cell field), `forchheimerCoeff` is a single scalar applied everywhere.
+Effective momentum sink: `−µ_eff · D · ⟨u⟩  −  F_c · ρ_f · |⟨u⟩| · √3 · D / |D|`. The Forchheimer term matters for high-velocity flow through coarse beds. For slow flow inside a fine porous medium the linear Darcy term is usually sufficient. Unlike `Df` (a per-cell field), `forchheimerCoeff` is a single scalar applied everywhere.
 
 ### `constant/radiationProperties`
 
@@ -367,7 +329,7 @@ The `Ts` (solid temperature) solver requires a tight tolerance (1e-10) for stabi
 ### `system/fvSchemes` — Key Settings
 
 ```cpp
-div(phiSolid)     Gauss upwind;   // MUST be upwind for solid advection stability
+div(phiSolid)     Gauss upwind;
 ```
 
 ### `system/controlDict` — Key Settings
@@ -398,6 +360,7 @@ maxDi           5000;       // Diffusion number limit (solid)
 | `YsDefault` | volScalarField | Default field for unmatched solid species (set to 0) |
 
 **Notes:**
+
 - `Df` is a tensor field. For isotropic porous media, use a diagonal tensor with large values (e.g. `1e9`) in gas-only regions and smaller values (based on permeability) in porous zones. Use the `setPorosity` utility to create appropriate fields.
 - Solid species field names: `Y` + component name from `solidThermophysicalProperties` (e.g. `wood` → `Ywood`).
 - Gas species field names match the `species` list in `chemistryProperties`.
@@ -410,13 +373,13 @@ Practical notes that are easy to get wrong on a first PGF case.
 
 Three approaches, in increasing order of complexity:
 
-1. **`setFields`** (with or without `setSet`): the standard OpenFOAM workflow. Specify a `setFieldsDict` that sets `porosityF` inside a cell zone to the desired void fraction and leaves the rest at `1.0`. `setFields` alone is sufficient for simple geometries; pair with `setSet` (batch mode) for more involved selection logic. Other fields (`T`, `Ts`, solid species mass fractions, …) can be initialised the same way. See `tutorials/cases/macroTGA_*` for an example chain (`blockMesh` → `setSet` → `refineHexMesh` → `setFields`).
+1. **`setFields`** (with or without `setSet`): the standard OpenFOAM workflow. Specify a `setFieldsDict` that sets `porosityF` inside a cell zone to the desired void fraction and leaves the rest at `1.0`. `setFields` alone is sufficient for simple geometries. Pair with `setSet` (batch mode) for more involved selection logic. Other fields (`T`, `Ts`, solid species mass fractions, …) can be initialised the same way. See `tutorials/cases/macroTGA_*` for an example chain (`blockMesh` → `setSet` → `refineHexMesh` → `setFields`).
 2. **STL + `setFields`**: for non-trivial bed geometries, build an STL of the porous region in Salome or Blender and feed it to `setSet`/`setFields` via a `surfaceToCell` selector.
-3. **`setPorosity` utility**: a code-driven generator (see `utilities/setPorosity/`). The user-editable description of the medium lives in `medium.H`; the tool must be recompiled after each change. Recommended only when scripted parametric sweeps are needed.
+3. **`setPorosity` utility** *(possibly outdated)*: a code-driven generator (see `utilities/setPorosity/`). The user-editable description of the medium lives in `medium.H` — the tool must be recompiled after each change. Kept for backward compatibility with older cases and parametric sweeps. For new cases, prefer approaches 1 and 2 above.
 
 ### Solid thermophysical properties: true density, not bulk
 
-Entries in `solidThermophysicalProperties` (`rho`, `K`, `Cp`, `Hf`) describe the **pure solid** — i.e. the material at `porosityF = 0`. The macroscopic bulk density inside the bed is then `ρ · (1 − φ)`; PGF reconstructs it from `porosityF` and the intrinsic `rho`. Literature often reports bulk values instead, so be careful: feeding a bulk density into `rho` understates the solid by a factor of `(1 − φ)`. The exception is the `gasifier` tutorial, which deliberately models the entire packed bed at the megascopic scale using bulk wood density (`rho 663` kg/m³ vs ≈ 1050 kg/m³ for true wood); this is a modelling choice consistent with treating the bed as a homogeneous Darcy medium.
+Entries in `solidThermophysicalProperties` (`rho`, `K`, `Cp`, `Hf`) describe the **pure solid** — i.e. the material at `porosityF = 0`. The macroscopic bulk density inside the bed is then `ρ · (1 − φ)`. PGF reconstructs it from `porosityF` and the intrinsic `rho`. Literature often reports bulk values instead, so be careful: feeding a bulk density into `rho` understates the solid by a factor of `(1 − φ)`.
 
 ### Gas species without JANAF data
 
@@ -424,26 +387,26 @@ Pyrolysis pseudo-species (e.g. lumped `tar`, `targas`) generally have no JANAF c
 
 ### Radiation parameters are the hardest to source
 
-The heterogeneous radiation coefficients (`a`, `as`, `borderAs`, `borderL`, `E`) rarely appear in literature with the right semantics. The recommended workflow is to tune them on a small TGA-like case so that the simulated heating rate matches an experiment, then reuse the tuned values across geometries that share the same surface chemistry and pellet morphology. The macroTGA tutorials are sized for exactly this calibration step.
+The heterogeneous radiation coefficients (`a`, `as`, `borderAs`, `borderL`, `E`) rarely appear in literature with the right semantics. A workable approach is to tune them on a small TGA-like case so that the simulated heating rate matches an experiment, then reuse the tuned values across geometries that share the same surface chemistry and pellet morphology.
 
 ### Time-step coupling between gas and solid chemistry
 
 Gas-phase reactions are typically orders of magnitude faster than heterogeneous solid reactions. When both are active, gas chemistry dominates the chemistry-limited time step and can make slow processes (e.g. gasification of a whole bed) very expensive. Practical implications:
 
 - For slow heterogeneous processes, prefer chemistry mechanisms with the minimum gas-phase detail needed for the result you care about.
-- `maxCo`, `maxDi`, and `initialChemicalTimeStep` in `controlDict` / `chemistryProperties` interact; tightening any one of them can mask the actual bottleneck. Check the solver log for which limit is binding before tuning.
+- `maxCo`, `maxDi`, and `initialChemicalTimeStep` in `controlDict` / `chemistryProperties` interact — tightening any one of them can mask the actual bottleneck. Check the solver log for which limit is binding before tuning.
 
 ### Mesh and parallel execution
 
-- Run `setPorosity` (if used) **before** `decomposePar`; it operates on the reconstructed mesh.
+- Run `setPorosity` (if used) **before** `decomposePar` — it operates on the reconstructed mesh.
 - The `totalMassPorousGasificationFoam` utility also requires a reconstructed case. Run `reconstructPar` first, or operate on the un-decomposed run.
 - `paraView -builtin` can visualise the decomposed processor directories directly without reconstruction — useful for very large cases.
-- Re-running a regression baseline must use the same `numberOfSubdomains` as the original; floating-point sensitivity to decomposition is real (see the "Regression Testing" section below).
+- Re-running a regression baseline must use the same `numberOfSubdomains` as the original — floating-point sensitivity to decomposition is real (see the "Regression Testing" section below).
 
 ## Utilities
 
-- **`setPorosity`** — generates `porosityF` and `Df` fields from medium parameters (particle diameter, tortuosity, permeability). Run inside the case directory before the simulation; the editable medium description lives in `utilities/setPorosity/medium.H`.
-- **`totalMassPorousGasificationFoam`** — post-processing diagnostic that writes `totalMass.txt` (time, integrated solid mass `∫ρ_s · (1−porosityF) dV`) for the run. Operates on a reconstructed case; run `reconstructPar` first if the case was decomposed.
+- **`setPorosity`** *(possibly outdated)* — generates `porosityF` and `Df` fields from medium parameters (particle diameter, tortuosity, permeability). Editable medium description in `utilities/setPorosity/medium.H`. Kept for backward compatibility — for new cases prefer the `setFields` + STL workflow (see [Tips](#biomass-distribution-initial-porosityf)).
+- **`totalMassPorousGasificationFoam`** — post-processing diagnostic that writes `totalMass.txt` (time, integrated solid mass `∫ρ_s · (1−porosityF) dV`) for the run. Operates on a reconstructed case — run `reconstructPar` first if the case was decomposed.
 
 ## Regression Testing
 
@@ -487,7 +450,7 @@ cd applications/test/regression
 ./Allrun --rtol 1e-3                    # override default relative tolerance
 ```
 
-Exit code 0 means all cases within tolerance; non-zero means at least one case failed. The script prints a per-case PASS/FAIL summary and, on failure, the rows that diverged.
+Exit code 0 means all cases within tolerance — non-zero means at least one case failed. The script prints a per-case PASS/FAIL summary and, on failure, the rows that diverged.
 
 ### What the comparison does
 
@@ -633,7 +596,7 @@ If you use this solver, please cite:
 
 ## Contributors
 
-Paweł Jan Żuk, Bartosz Tużnik, Tadeusz Rymarz, Zhiwar, Kamil Kwiatkowski, Marek Dudyński, Flavio C. C. Galeazzo, Guenther C. Krieger Filho, Filip Mróz (foam-extend-4.1 to v2406 port)
+Paweł Jan Żuk, Bartosz Tużnik, Tadeusz Rymarz, Ali Ebrahimi Pure, Kamil Kwiatkowski, Marek Dudyński, Flavio C. C. Galeazzo, Guenther C. Krieger Filho, Filip Mróz (foam-extend-4.1 to v2406 port)
 
 ## For AI Coding Agents
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Reported and plausible application areas include:
 14. [Porosity Evolution and Bed Motion](#porosity-evolution-and-bed-motion)
 15. [Gas-Solid Coupling](#gas-solid-coupling)
 
-[Citation](#citation) · [Contributors](#contributors)
+[Development Workflow](#development-workflow) · [Citation](#citation) · [Contributors](#contributors)
 
 ---
 
@@ -783,6 +783,63 @@ Term definitions:
 - `Q_heatUpGas = Sρ · Cp_gas · (Ts − Tg)` [W/m³] — energy needed to heat pyrolysis products from `Ts` to `Tg`.
 - `Sh_chem` (`chemistrySh_`) [W/m³] — heterogeneous reaction heat.
 - `radiation->Sh()` [W/m³] — radiative source term, sign depending on local emission/absorption balance.
+
+---
+
+## Development Workflow
+
+*Contributing to this repository. New contributors: start here.*
+
+### Branch Naming
+
+Branches use a short prefix that signals intent, followed by a kebab-case descriptive name. Five prefixes cover everything:
+
+| Prefix | Used for |
+|---|---|
+| `feature/` | New user-facing capability — a new solver field, model, or tutorial exercising real functionality. |
+| `fix/` | Observable bug becomes right. |
+| `refactor/` | Code restructure intended not to change behaviour. Flag for careful review. |
+| `docs/` | Documentation only (README, AGENTS.md, comments). |
+| `chore/` | Everything else meta — formatter configs, build/Make tweaks, `.gitignore`, dependency bumps, tooling. |
+
+Examples: `feature/UsInterp-laplace-smoothing`, `fix/regression-allrun-set-u`, `chore/format-and-docs`.
+
+A single branch may bundle multiple low-risk meta concerns (e.g. formatter, docs, and dev-workflow changes can ride on one `chore/...` branch). Anything that can affect numerical results stays on its own branch.
+
+### Merge Strategy
+
+The repository uses **squash merge** — each PR becomes one commit on `main`, whose message is the PR title followed by the PR body. This keeps `main` linear and easy to scan with `git log --oneline`, while preserving the *why* and verification context inside `git log` / `git show`.
+
+Because the squash commit is permanent and per-branch commits are not, the convention below applies to **PR titles and bodies**, not to individual commits on your working branch. Commit however you like locally; the squash collapses it.
+
+### PR Titles
+
+```
+<type>[(<scope>)]: <imperative subject>
+```
+
+- `<type>` is one of `feat`, `fix`, `refactor`, `docs`, `chore` — the same vocabulary as branch prefixes (`feat` is the short form of `feature`).
+- `<scope>` is optional. Use it when it adds clarity (e.g. `fix(regression): ...` vs an unrelated bug fix). Plausible scopes in this repo: `regression`, `DEM`, `solver`, `tutorials`, `README`, `AGENTS`, `pyrolysis`, `chemistry`.
+- Subject is in imperative mood, lowercase first letter after the colon, ≤72 characters, no trailing period.
+
+Examples:
+
+```
+feat(DEM): add UsInterp Laplace smoothing for solid velocity
+fix(regression): keep Allrun/Allclean working under set -u
+docs(README): clarify default chemistry
+chore: apply clang-format across solver
+```
+
+### PR Body
+
+Opening a PR auto-populates the description from `.github/pull_request_template.md`. Three sections:
+
+- **Summary** — one or two sentences on what the PR changes. Always fill this in.
+- **Why** — motivation: symptom, missing capability, or bug. Skip if the diff is obviously self-justifying (typo fix, formatter run).
+- **Verification** — what you actually ran or checked: build target, tutorial cases, regression suite, residual sanity. Skip if the change cannot affect runtime (README only).
+
+Aim for terse and specific. The body becomes part of `main`'s history once squash-merged, so future-you (and `git log`) benefit from precision now.
 
 ---
 

--- a/porousGasificationMedia/DEM/Make/options
+++ b/porousGasificationMedia/DEM/Make/options
@@ -3,8 +3,8 @@ sinclude $(RULES)/mplib$(WM_MPLIB)
 EXE_INC = \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(LIB_SRC)/meshTools/lnInclude	\
-    -I$(YADE_TRUNK)/pkg/openfoam/coupling/FoamYade/lnInclude \
-    -I$(YADE_TRUNK)/pkg/openfoam/coupling/FoamYade/meshtree/lnInclude \
+    -I$(YADE_TRUNK)pkg/openfoam/coupling/FoamYade/lnInclude \
+    -I$(YADE_TRUNK)pkg/openfoam/coupling/FoamYade/meshtree/lnInclude \
     -I$(LIB_SRC)/Pstream/mpi/lnInclude  \
     $(PFLAGS) $(PINC) \
     -DfoamVersion=$(shell echo $(WM_PROJECT_VERSION) | sed 's/v//g')


### PR DESCRIPTION
  ## Summary
  Meta bucket. README restructured into Part I (practical) / Part II (tour into source code), `.clang-format` and DEM
  `Make/options` added, a new Development Workflow section documents branch naming and PR conventions with a matching
  `.github/pull_request_template.md`, and a "Documentation" sub-section codifies the rule that physics belongs in
  source-code comments — with the agent-targeted version mirrored in AGENTS.md.

  ## Why
  Four pieces, each too small to justify its own PR cycle, all non-behavioural, all reviewable with the same "does this
  look right?" mindset:
  - README's Part I/II split (continued from PR #10) broadens use cases beyond gasification and trims agent-targeted prose.
  - `.clang-format` plus the `Make/options` tweak prepare for consistent code formatting across the solver (formatter rules
   are back-engineered from current appearance and will be tightened in a follow-up).
  - Development Workflow section formalises branch naming, squash-merge with PR title+body, and a simple PR template so
  future contributors and AI agents don't re-derive the convention.
  - Part II was rewriting equations and algorithm details that the code itself is a better home for. It already had drift
  (missing DEM block, sub-step miscount, unverified reaction keywords) a few commits after being rewritten. Replaced with a
   short tour; the "Documentation" rule codifies that physics belongs in source-code comments going forward. Code comments
  are not added in this PR — migration is opportunistic, file-by-file, as the solver gets touched on feature work.

  ## Verification
  - No solver code or tutorial regression cases touched; numerical regression untouched by definition.
  - `.clang-format` not yet applied to existing sources; this PR only adds the config.
  - README renders cleanly; the renamed Part II anchors (`#per-time-step-tour`, `#where-to-look-for-what`) resolve, and the
   new TOC entry for `#development-workflow` resolves.
