### PR TITLE
fix(yade): restore DEM coupling silently broken since WITH_YADE was added to the solver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ linux64GccDPInt32Opt/
 *.foam
 lnInclude/
 simulation_logs
+dtInfo.txt
+run.log

--- a/README.md
+++ b/README.md
@@ -122,8 +122,10 @@ Run `build.sh --help` for all options.
 ### YADE DEM coupling
 
 ```bash
-WITH_YADE=1 ./build.sh build --all
+./build.sh build --yade
 ```
+
+`--yade` enables the `DEM` library target and compiles the solver with `WITH_YADE=1`, which activates the `#ifdef WITH_YADE` DEM coupling blocks. Without this flag the solver is built without DEM support and Yade will hang waiting for MPI communication.
 
 Requires YADE installed with the OpenFOAM coupling module.
 

--- a/applications/test/regression/Allrun.yade
+++ b/applications/test/regression/Allrun.yade
@@ -48,6 +48,7 @@ if [ "${#CASE_LINES[@]}" -eq 0 ]; then
 fi
 
 [ "$SHORT_RUN" -eq 1 ] && export YADE_NSTEPS=200
+[ "$SHORT_RUN" -eq 1 ] && export YADE_TIMEOUT=300
 
 clog INFO "=================================================="
 clog INFO "  PGF Yade regression suite"

--- a/applications/test/regression/Allrun.yade
+++ b/applications/test/regression/Allrun.yade
@@ -48,7 +48,7 @@ if [ "${#CASE_LINES[@]}" -eq 0 ]; then
 fi
 
 [ "$SHORT_RUN" -eq 1 ] && export YADE_NSTEPS=200
-[ "$SHORT_RUN" -eq 1 ] && export YADE_TIMEOUT=180
+[ "$SHORT_RUN" -eq 1 ] && export YADE_TIMEOUT=300
 
 clog INFO "=================================================="
 clog INFO "  PGF Yade regression suite"

--- a/applications/test/regression/Allrun.yade
+++ b/applications/test/regression/Allrun.yade
@@ -17,19 +17,24 @@ set +u; . "$REPO_ROOT/utilities/bash_utils/helpers.sh"; set -u
 
 CASES_FILE="$SCRIPT_DIR/cases_yade.list"
 ONLY_CASE=""
+SHORT_RUN=0
 
 usage() {
     cat <<EOF
-Usage: $0 [--case <name>]
+Usage: $0 [--case <name>] [--short]
 
   --case <name>   Run only the named case (basename or repo-relative path).
+  --short         Fast smoke test: set YADE_NSTEPS=200 so each case runs in
+                  seconds instead of hours. Checks coupling handshake and VTK
+                  output without running a full simulation.
   -h, --help      Show this help.
 EOF
 }
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --case) ONLY_CASE="$2"; shift 2 ;;
+        --case)  ONLY_CASE="$2"; shift 2 ;;
+        --short) SHORT_RUN=1; shift ;;
         -h|--help) usage; exit 0 ;;
         *) clog ERROR "Unknown option: $1"; usage; exit 2 ;;
     esac
@@ -42,9 +47,12 @@ if [ "${#CASE_LINES[@]}" -eq 0 ]; then
     exit 0
 fi
 
+[ "$SHORT_RUN" -eq 1 ] && export YADE_NSTEPS=200
+
 clog INFO "=================================================="
 clog INFO "  PGF Yade regression suite"
 [ -n "$ONLY_CASE" ] && clog INFO "  filter: $ONLY_CASE"
+[ "$SHORT_RUN" -eq 1 ] && clog INFO "  mode: --short (YADE_NSTEPS=200)"
 clog INFO "=================================================="
 
 passed=()

--- a/applications/test/regression/Allrun.yade
+++ b/applications/test/regression/Allrun.yade
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Yade DEM regression runner.
+# Runs each case in cases_yade.list, relying on the case's own Allrun to check
+# DEM output (sphere/spring VTK file presence assertions are in each Allrun).
+#
+# Requirements: solver built with ./build.sh --yade, Yade + mpirun installed.
+#
+# Usage:
+#   applications/test/regression/Allrun.yade [--case <name>]
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+set +u; . "$REPO_ROOT/utilities/bash_utils/helpers.sh"; set -u
+
+CASES_FILE="$SCRIPT_DIR/cases_yade.list"
+ONLY_CASE=""
+
+usage() {
+    cat <<EOF
+Usage: $0 [--case <name>]
+
+  --case <name>   Run only the named case (basename or repo-relative path).
+  -h, --help      Show this help.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --case) ONLY_CASE="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) clog ERROR "Unknown option: $1"; usage; exit 2 ;;
+    esac
+done
+
+mapfile -t CASE_LINES < <(grep -vE '^\s*(#|$)' "$CASES_FILE")
+
+if [ "${#CASE_LINES[@]}" -eq 0 ]; then
+    clog WARNING "No cases listed in $CASES_FILE"
+    exit 0
+fi
+
+clog INFO "=================================================="
+clog INFO "  PGF Yade regression suite"
+[ -n "$ONLY_CASE" ] && clog INFO "  filter: $ONLY_CASE"
+clog INFO "=================================================="
+
+passed=()
+failed=()
+pass_times=()
+fail_times=()
+
+for caseRel in "${CASE_LINES[@]}"; do
+    caseName="$(basename "$caseRel")"
+
+    if [ -n "$ONLY_CASE" ] && [ "$caseName" != "$ONLY_CASE" ] && [ "$caseRel" != "$ONLY_CASE" ]; then
+        continue
+    fi
+
+    caseDir="$REPO_ROOT/$caseRel"
+
+    clog INFO "--------------------------------------------------"
+    clog INFO "  case: $caseName"
+
+    if [ ! -d "$caseDir" ]; then
+        clog ERROR "  directory missing: $caseDir"
+        failed+=("$caseName (missing dir)")
+        fail_times+=("-")
+        continue
+    fi
+
+    if [ ! -x "$caseDir/Allclean" ]; then
+        clog WARNING "  no Allclean — proceeding without clean"
+    else
+        (cd "$caseDir" && ./Allclean) >/dev/null 2>&1 || true
+    fi
+
+    t_start=$(date +%s)
+    if (cd "$caseDir" && ./Allrun); then
+        t_elapsed=$(( $(date +%s) - t_start ))
+        clog SUCCESS "  PASS  (${t_elapsed}s)"
+        passed+=("$caseName")
+        pass_times+=("${t_elapsed}s")
+    else
+        t_elapsed=$(( $(date +%s) - t_start ))
+        clog ERROR "  FAIL  (${t_elapsed}s)"
+        failed+=("$caseName")
+        fail_times+=("${t_elapsed}s")
+    fi
+done
+
+total=$(( ${#passed[@]} + ${#failed[@]} ))
+echo
+clog INFO "=================================================="
+clog INFO "  Yade regression summary  ($total cases)"
+clog INFO "=================================================="
+
+i=0
+for c in "${passed[@]}"; do clog SUCCESS "  PASS  ${pass_times[$i]}  $c"; (( i++ )) || true; done
+i=0
+for c in "${failed[@]}"; do clog ERROR   "  FAIL  ${fail_times[$i]}  $c"; (( i++ )) || true; done
+
+echo
+clog INFO "  passed: ${#passed[@]}   failed: ${#failed[@]}"
+clog INFO "=================================================="
+
+[ "${#failed[@]}" -gt 0 ] && exit 1
+exit 0

--- a/applications/test/regression/Allrun.yade
+++ b/applications/test/regression/Allrun.yade
@@ -48,7 +48,7 @@ if [ "${#CASE_LINES[@]}" -eq 0 ]; then
 fi
 
 [ "$SHORT_RUN" -eq 1 ] && export YADE_NSTEPS=200
-[ "$SHORT_RUN" -eq 1 ] && export YADE_TIMEOUT=300
+[ "$SHORT_RUN" -eq 1 ] && export YADE_TIMEOUT=120
 
 clog INFO "=================================================="
 clog INFO "  PGF Yade regression suite"

--- a/applications/test/regression/Allrun.yade
+++ b/applications/test/regression/Allrun.yade
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Yade DEM regression runner.
-# Runs each case in cases_yade.list, relying on the case's own Allrun to check
-# DEM output (sphere/spring VTK file presence assertions are in each Allrun).
+# Runs each case in cases_yade.list; test-mode controls and validation are in
+# tools/runDEMCase.sh (not in the tutorial Allrun scripts).
 #
 # Requirements: solver built with ./build.sh --yade, Yade + mpirun installed.
 #
@@ -48,7 +48,7 @@ if [ "${#CASE_LINES[@]}" -eq 0 ]; then
 fi
 
 [ "$SHORT_RUN" -eq 1 ] && export YADE_NSTEPS=200
-[ "$SHORT_RUN" -eq 1 ] && export YADE_TIMEOUT=120
+[ "$SHORT_RUN" -eq 1 ] && export YADE_TIMEOUT=180
 
 clog INFO "=================================================="
 clog INFO "  PGF Yade regression suite"
@@ -80,14 +80,8 @@ for caseRel in "${CASE_LINES[@]}"; do
         continue
     fi
 
-    if [ ! -x "$caseDir/Allclean" ]; then
-        clog WARNING "  no Allclean — proceeding without clean"
-    else
-        (cd "$caseDir" && ./Allclean) >/dev/null 2>&1 || true
-    fi
-
     t_start=$(date +%s)
-    if (cd "$caseDir" && ./Allrun); then
+    if "$SCRIPT_DIR/tools/runDEMCase.sh" "$caseDir"; then
         t_elapsed=$(( $(date +%s) - t_start ))
         clog SUCCESS "  PASS  (${t_elapsed}s)"
         passed+=("$caseName")

--- a/applications/test/regression/cases.list
+++ b/applications/test/regression/cases.list
@@ -12,6 +12,9 @@
 #   2. #includeIfPresent it from system/controlDict (functions block)
 #   3. Capture a reference/postProcessing/ baseline locally
 #   4. Add the path here with an appropriate tag
+#
+# DEM/Yade cases use a separate runner: applications/test/regression/Allrun.yade
+# (they require Yade installed and the solver built with ./build.sh --yade).
 
 tutorials/cases/charOnlyMoveSerial        fast
 tutorials/cases/charOnlyMoveSerial_m2     convergence

--- a/applications/test/regression/cases_yade.list
+++ b/applications/test/regression/cases_yade.list
@@ -1,0 +1,12 @@
+# DEM (Yade) tutorial cases for the Yade regression runner (Allrun.yade).
+# Requires: solver built with ./build.sh --yade, Yade installed, mpirun available.
+#
+# Format: one case path per line (relative to repo root).
+# The case's Allrun must exit 0 on success and assert its own output
+# (sphere/spring VTK existence checks are already in each case's Allrun).
+#
+# Run with:
+#   applications/test/regression/Allrun.yade
+
+tutorials/cases/DEM_UsInterp_solidU
+tutorials/cases/DEM_UsInterp_solidU_test2

--- a/applications/test/regression/cases_yade.list
+++ b/applications/test/regression/cases_yade.list
@@ -10,3 +10,4 @@
 
 tutorials/cases/DEM_UsInterp_solidU
 tutorials/cases/DEM_UsInterp_solidU_test2
+tutorials/cases/MicroTGA-DEM_Us_UsInterp

--- a/applications/test/regression/tools/runDEMCase.sh
+++ b/applications/test/regression/tools/runDEMCase.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Test-mode runner for a single DEM/Yade case. Called by Allrun.yade — not for direct use.
+# Usage: runDEMCase.sh <abs-path-to-case-dir>
+set -u
+
+CASE_DIR="$1"
+NSTEPS="${YADE_NSTEPS:-2000000}"
+TIMEOUT="${YADE_TIMEOUT:-3600}"
+
+cd "$CASE_DIR"
+./Allclean 2>/dev/null || true
+
+echo "  running DEM simulation (NSTEPS=$NSTEPS, timeout=${TIMEOUT}s)..."
+timeout "$TIMEOUT" bash ./Allrun > run.log 2>&1 || true
+pkill -f "porousGasificationFoam" 2>/dev/null || true
+
+grep -q "RUN FINISH" run.log \
+    || { echo "ERROR: simulation did not complete — check run.log"; exit 1; }
+grep -q "DEM coupling: active" run.log \
+    || { echo "ERROR: DEM coupling not active — solver built without -DWITH_YADE=1?"; exit 1; }
+ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; exit 1; }
+ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; exit 1; }
+echo "  DEM output check passed"
+
+[ -f dtInfo.txt ] \
+    || { echo "ERROR: dtInfo.txt not written — did the run reach iter 1?"; exit 1; }
+if ! python3 - <<'PYCHECK'
+import sys
+lines = [l for l in open("dtInfo.txt") if not l.startswith("iter") and l.strip()]
+if not lines:
+    print("ERROR: dtInfo.txt empty — coupling did not reach iter 1"); sys.exit(1)
+foamDt = float(lines[0].split()[3])
+if foamDt <= 0.0:
+    print("ERROR: foamDt={:.3e} — PGF time step not received".format(foamDt)); sys.exit(1)
+print("  PGF coupling check passed (foamDt={:.3e})".format(foamDt))
+PYCHECK
+then exit 1; fi

--- a/build.sh
+++ b/build.sh
@@ -23,6 +23,9 @@ declare -A BUILD_TARGETS=( # default values
   [utilities]=1
 )
 
+# Set to 1 via --yade to compile the solver with Yade/DEM coupling support
+WITH_YADE=0
+
 declare -A TARGET_DIRS=(
   [DEM]="$FOAM_HGS/DEM"
   [fieldPorosityModel]="$FOAM_HGS/fieldPorosityModel"
@@ -95,14 +98,21 @@ parse_arguments() {
       local t="${1#--no-}"
       BUILD_TARGETS[$t]=0
       ;;
+    --yade)
+      WITH_YADE=1
+      BUILD_TARGETS[DEM]=1
+      ;;
     --dry-run)
       dry_run
       exit 0
       ;;
     --help)
       echo "Usage: $0 [build|clean] [OPTIONS]"
-      echo "Options: --reset-all, --all, --libs-only, --apps-only"
+      echo "Options: --reset-all, --all, --libs-only, --apps-only, --yade"
       echo "Targets: ${ALL_TARGETS_FLAGS[*]} ${ALL_TARGETS_NO_FLAGS[*]}"
+      echo ""
+      echo "  --yade   Build the DEM library and solver with WITH_YADE=1"
+      echo "           (required for Yade-coupled DEM simulations)"
       exit 0
       ;;
     *)
@@ -169,7 +179,12 @@ execute_target() {
 
   if [ "$MODE" = "build" ]; then
     cmd="${BUILD_COMMANDS[$target]}"
-    clog INFO "Building $target..."
+    if [ "$target" = "porousGasificationFoam" ] && [ "$WITH_YADE" -eq 1 ]; then
+      cmd="WITH_YADE=1 ${cmd}"
+      clog INFO "Building $target (WITH_YADE=1)..."
+    else
+      clog INFO "Building $target..."
+    fi
   else
     cmd="${CLEAN_COMMANDS[$target]}"
     clog INFO "Cleaning $target..."
@@ -211,6 +226,11 @@ dry_run() {
   echo "════════════════════════════════════════════════════════════"
   echo ""
 
+  echo "OPTIONS:"
+  echo "────────────────────────────────────────────────────────────"
+  printf "  WITH_YADE=%s\n" "$WITH_YADE"
+  echo ""
+
   echo "BUILD TARGETS STATUS:"
   echo "────────────────────────────────────────────────────────────"
   for t in "${ALL_TARGETS[@]}"; do
@@ -233,6 +253,9 @@ dry_run() {
       local cmd
       if [ "$MODE" = "build" ]; then
         cmd="${BUILD_COMMANDS[$target]}"
+        if [ "$target" = "porousGasificationFoam" ] && [ "$WITH_YADE" -eq 1 ]; then
+          cmd="WITH_YADE=1 ${cmd}"
+        fi
       else
         cmd="${CLEAN_COMMANDS[$target]}"
       fi

--- a/build.sh
+++ b/build.sh
@@ -290,7 +290,7 @@ main() {
 }
 
 _build_completion() {
-  local opts="build clean --reset-all --all --libs-only --apps-only ${ALL_TARGETS_FLAGS[*]} ${ALL_TARGETS_NO_FLAGS[*]} --help --dry-run"
+  local opts="build clean --reset-all --all --libs-only --apps-only --yade ${ALL_TARGETS_FLAGS[*]} ${ALL_TARGETS_NO_FLAGS[*]} --help --dry-run"
   COMPREPLY=($(compgen -W "$opts" -- "${COMP_WORDS[COMP_CWORD]}"))
 }
 

--- a/porousGasificationFoam/Make/options
+++ b/porousGasificationFoam/Make/options
@@ -48,6 +48,7 @@ EXE_LIBS = \
 
 ifeq ($(WITH_YADE),1)
     EXE_INC += \
+        -DWITH_YADE=1 \
         -I$(YADE_TRUNK)/pkg/openfoam/coupling/FoamYade/lnInclude
 
     EXE_LIBS += \

--- a/porousGasificationFoam/createDEMFields.H
+++ b/porousGasificationFoam/createDEMFields.H
@@ -11,6 +11,14 @@ IOdictionary yadeCouplingProperties
 
 Switch DEM(yadeCouplingProperties.lookupOrDefault<Switch>("active", false));
 
+Info << "DEM coupling: "
+     << (DEM ? "active" : "inactive (yadeProperties absent or active=false)")
+     << nl;
+
+if (yadeCouplingProperties.size() > 0 && !DEM)
+    WarningIn("createDEMFields.H")
+        << "yadeProperties found but DEM coupling is disabled (active != true)" << nl;
+
 
 dimensionedScalar nu (
     "nu",

--- a/porousGasificationFoam/createDEMFields.H
+++ b/porousGasificationFoam/createDEMFields.H
@@ -174,7 +174,7 @@ volVectorField UsDEM(
     runTime.timeName(),
     mesh,
     IOobject::NO_READ,
-    IOobject::NO_WRITE),
+    IOobject::AUTO_WRITE),
     mesh,
     dimensionedVector("UsDEM", dimensionSet(0,1,-1,0,0,0,0), vector(0,0,0) )
 );

--- a/porousGasificationFoam/porousGasificationFoam.C
+++ b/porousGasificationFoam/porousGasificationFoam.C
@@ -114,9 +114,9 @@ int main(int argc, char *argv[])
         if (DEM)
         {
             vGrad = fvc::grad(U);
+            lambdaDotUpdater->update();
             yadeCoupling->setParticleAction(runTime.deltaT().value());
-            lambdaDotUpdater->update(); //DasteXar jadid
-            lambdaDotUpdater->writeParticlesData(); // DasteXar to write ParticlesData.txt in each time step for each rank
+            lambdaDotUpdater->writeParticlesData();
             yadeCoupling->setSourceZero();
         }
         #endif

--- a/porousGasificationMedia/DEM/lambdaDotModel.C
+++ b/porousGasificationMedia/DEM/lambdaDotModel.C
@@ -75,14 +75,13 @@ void lambdaDotModel::update()
         {
             if (!partPtr) continue;
 
-            label cellI = mesh_.findCell(partPtr->pos);
-            if (cellI >= 0)
-            {
-                nParticles_[cellI] += 1.0;
+            label cellI = partPtr->inCell;
+            if (cellI < 0) continue;
 
-                // sum particle velocities into the cell
-                UsDEM_[cellI] += partPtr->linearVelocity;
-            }
+            nParticles_[cellI] += 1.0;
+
+            // sum particle velocities into the cell
+            UsDEM_[cellI] += partPtr->linearVelocity;
         }
     }
 
@@ -145,8 +144,7 @@ void lambdaDotModel::update()
         {
             if (!partPtr) continue;
 
-            label cellI = mesh_.findCell(partPtr->pos);
-
+            label cellI = partPtr->inCell;
             if (cellI < 0) continue;
             if (nParticles_[cellI] < 0.5) continue;
 
@@ -182,7 +180,7 @@ void lambdaDotModel::writeParticlesData() const
         {
             if (!partPtr) continue;
 
-            label cellI = mesh_.findCell(partPtr->pos);
+            label cellI = partPtr->inCell;
             if (cellI < 0) continue;
             if (nParticles_[cellI] < 0.5) continue;
 

--- a/porousGasificationMedia/pyrolysisModels/pyrolysisModel/volPyrolysis/volPyrolysis.C
+++ b/porousGasificationMedia/pyrolysisModels/pyrolysisModel/volPyrolysis/volPyrolysis.C
@@ -593,18 +593,12 @@ volPyrolysis::volPyrolysis
         dimensionedTensor("one", dimless, tensor(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
     ),
     surfF_(whereIs_),
+    // Bind to the single registered "Us" field created by the solver
+    // (createFields.H), rather than owning a duplicate. lambdaDotModel
+    // writes that same object when DEM coupling is active.
     Us_
     (
-        IOobject
-        (
-            "Us",
-            time_.timeName(),
-            mesh_,
-            IOobject::READ_IF_PRESENT,
-            IOobject::AUTO_WRITE
-        ),
-        mesh_,
-        dimensionedVector("Us", dimensionSet(0,1,-1,0,0,0,0), Foam::vector(0,0,0))
+        mesh_.lookupObject<volVectorField>("Us")
     ),
     lostSolidMass_(dimensionedScalar("zero", dimMass, 0.0)),
     addedGasMass_(dimensionedScalar("zero", dimMass, 0.0)),
@@ -992,18 +986,12 @@ volPyrolysis::volPyrolysis
         mesh_,
         dimensionedScalar("zero", dimless, 0.0)
     ),
+    // Bind to the single registered "Us" field created by the solver
+    // (createFields.H), rather than owning a duplicate. lambdaDotModel
+    // writes that same object when DEM coupling is active.
     Us_
     (
-        IOobject
-        (
-            "Us",
-            time_.timeName(),
-            mesh_,
-            IOobject::READ_IF_PRESENT,
-            IOobject::AUTO_WRITE
-        ),
-        mesh_,
-        dimensionedVector("Us", dimensionSet(0,1,-1,0,0,0,0), Foam::vector(0,0,0))
+        mesh_.lookupObject<volVectorField>("Us")
     ),
     lostSolidMass_(dimensionedScalar("zero", dimMass, 0.0)),
     addedGasMass_(dimensionedScalar("zero", dimMass, 0.0)),

--- a/porousGasificationMedia/pyrolysisModels/pyrolysisModel/volPyrolysis/volPyrolysis.H
+++ b/porousGasificationMedia/pyrolysisModels/pyrolysisModel/volPyrolysis/volPyrolysis.H
@@ -193,8 +193,12 @@ protected:
         //- border cells inside solid body
         volScalarField surfF_;
 
-        //- solid phase velocity
-        volVectorField Us_;
+        //- Solid-phase velocity. Read-only reference to the single "Us"
+        //  field registered by the solver (createFields.H). With DEM
+        //  coupling it is overwritten each step by lambdaDotModel from the
+        //  Laplace-smoothed UsDEM aggregate; without DEM it is read from
+        //  0/Us. The solid mass flux and porosity advection consume it.
+        const volVectorField& Us_;
 
     // Checks
 

--- a/tutorials/cases/DEM_UsInterp_solidU/Allclean
+++ b/tutorials/cases/DEM_UsInterp_solidU/Allclean
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-rm -rf -- processor* 0 0.[1-9]* [1-9]* log log.analyzed postProcessing constant/polyMesh dynamicCode log* spheres/* springs/*
+rm -rf -- processor* 0 0.[1-9]* [1-9]* log log.analyzed postProcessing constant/polyMesh dynamicCode log* spheres/* springs/* dtInfo.txt run.log

--- a/tutorials/cases/DEM_UsInterp_solidU/Allrun
+++ b/tutorials/cases/DEM_UsInterp_solidU/Allrun
@@ -10,8 +10,10 @@ mkdir -p spheres springs
 NSTEPS="${YADE_NSTEPS:-2000000}"
 TIMEOUT="${YADE_TIMEOUT:-3600}"
 echo "  running DEM simulation (NSTEPS=$NSTEPS, timeout=${TIMEOUT}s)..."
-timeout "$TIMEOUT" mpirun --allow-run-as-root -n 2 yade MPI_lambda.py > run.log 2>&1 \
-    || { echo "ERROR: simulation failed or timed out — check run.log"; exit 1; }
+timeout "$TIMEOUT" mpirun --allow-run-as-root -n 2 yade MPI_lambda.py > run.log 2>&1 || true
+pkill -f "porousGasificationFoam" 2>/dev/null || true
+grep -q "RUN FINISH" run.log \
+    || { echo "ERROR: simulation did not complete — check run.log"; exit 1; }
 
 grep -q "DEM coupling: active" run.log \
     || { echo "ERROR: DEM coupling not active — solver built without -DWITH_YADE=1?"; exit 1; }

--- a/tutorials/cases/DEM_UsInterp_solidU/Allrun
+++ b/tutorials/cases/DEM_UsInterp_solidU/Allrun
@@ -6,31 +6,4 @@ blockMesh   > /dev/null 2>&1
 setFields   > /dev/null 2>&1
 decomposePar > /dev/null 2>&1
 mkdir -p spheres springs
-
-NSTEPS="${YADE_NSTEPS:-2000000}"
-TIMEOUT="${YADE_TIMEOUT:-3600}"
-echo "  running DEM simulation (NSTEPS=$NSTEPS, timeout=${TIMEOUT}s)..."
-timeout "$TIMEOUT" mpirun --allow-run-as-root -n 2 yade MPI_lambda.py > run.log 2>&1 || true
-pkill -f "porousGasificationFoam" 2>/dev/null || true
-grep -q "RUN FINISH" run.log \
-    || { echo "ERROR: simulation did not complete — check run.log"; exit 1; }
-
-grep -q "DEM coupling: active" run.log \
-    || { echo "ERROR: DEM coupling not active — solver built without -DWITH_YADE=1?"; exit 1; }
-ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; exit 1; }
-ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; exit 1; }
-echo "  DEM output check passed"
-
-[ -f dtInfo.txt ] \
-    || { echo "ERROR: dtInfo.txt not written — did the run reach iter 1?"; exit 1; }
-if ! python3 - <<'PYCHECK'
-import sys
-lines = [l for l in open("dtInfo.txt") if not l.startswith("iter") and l.strip()]
-if not lines:
-    print("ERROR: dtInfo.txt empty — coupling did not reach iter 1"); sys.exit(1)
-foamDt = float(lines[0].split()[3])
-if foamDt <= 0.0:
-    print("ERROR: foamDt={:.3e} — PGF time step not received".format(foamDt)); sys.exit(1)
-print("  PGF coupling check passed (foamDt={:.3e})".format(foamDt))
-PYCHECK
-then exit 1; fi
+mpirun --allow-run-as-root -n 2 yade MPI_lambda.py

--- a/tutorials/cases/DEM_UsInterp_solidU/Allrun
+++ b/tutorials/cases/DEM_UsInterp_solidU/Allrun
@@ -14,3 +14,17 @@ grep -q "DEM coupling: active" run.log \
 ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; exit 1; }
 ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; exit 1; }
 echo "DEM output check passed"
+
+[ -f dtInfo.txt ] \
+    || { echo "ERROR: dtInfo.txt not written — did the run reach iter 1?"; exit 1; }
+if ! python3 - <<'PYCHECK'
+import sys
+lines = [l for l in open("dtInfo.txt") if not l.startswith("iter") and l.strip()]
+if not lines:
+    print("ERROR: dtInfo.txt empty — coupling did not reach iter 1"); sys.exit(1)
+foamDt = float(lines[0].split()[3])
+if foamDt <= 0.0:
+    print("ERROR: foamDt={:.3e} — PGF time step not received".format(foamDt)); sys.exit(1)
+print("PGF coupling check passed (foamDt={:.3e})".format(foamDt))
+PYCHECK
+then exit 1; fi

--- a/tutorials/cases/DEM_UsInterp_solidU/Allrun
+++ b/tutorials/cases/DEM_UsInterp_solidU/Allrun
@@ -2,18 +2,22 @@
 # Requires a Yade-enabled solver build: ./build.sh --yade
 
 cp -r 0_orig 0
-blockMesh
-setFields
-decomposePar
+blockMesh   > /dev/null 2>&1
+setFields   > /dev/null 2>&1
+decomposePar > /dev/null 2>&1
 mkdir -p spheres springs
 
-mpirun --allow-run-as-root -n 2 yade MPI_lambda.py 2>&1 | tee run.log
+NSTEPS="${YADE_NSTEPS:-2000000}"
+TIMEOUT="${YADE_TIMEOUT:-3600}"
+echo "  running DEM simulation (NSTEPS=$NSTEPS, timeout=${TIMEOUT}s)..."
+timeout "$TIMEOUT" mpirun --allow-run-as-root -n 2 yade MPI_lambda.py > run.log 2>&1 \
+    || { echo "ERROR: simulation failed or timed out — check run.log"; exit 1; }
 
 grep -q "DEM coupling: active" run.log \
     || { echo "ERROR: DEM coupling not active — solver built without -DWITH_YADE=1?"; exit 1; }
 ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; exit 1; }
 ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; exit 1; }
-echo "DEM output check passed"
+echo "  DEM output check passed"
 
 [ -f dtInfo.txt ] \
     || { echo "ERROR: dtInfo.txt not written — did the run reach iter 1?"; exit 1; }
@@ -25,6 +29,6 @@ if not lines:
 foamDt = float(lines[0].split()[3])
 if foamDt <= 0.0:
     print("ERROR: foamDt={:.3e} — PGF time step not received".format(foamDt)); sys.exit(1)
-print("PGF coupling check passed (foamDt={:.3e})".format(foamDt))
+print("  PGF coupling check passed (foamDt={:.3e})".format(foamDt))
 PYCHECK
 then exit 1; fi

--- a/tutorials/cases/DEM_UsInterp_solidU/Allrun
+++ b/tutorials/cases/DEM_UsInterp_solidU/Allrun
@@ -7,7 +7,7 @@ setFields
 decomposePar
 mkdir -p spheres springs
 
-timeout 60 mpirun --allow-run-as-root -n 2 yade MPI_lambda.py 2>&1 | tee run.log || true
+mpirun --allow-run-as-root -n 2 yade MPI_lambda.py
 
 ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; exit 1; }
 ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; exit 1; }

--- a/tutorials/cases/DEM_UsInterp_solidU/Allrun
+++ b/tutorials/cases/DEM_UsInterp_solidU/Allrun
@@ -7,7 +7,7 @@ setFields
 decomposePar
 mkdir -p spheres springs
 
-mpirun --allow-run-as-root -n 2 yade MPI_lambda.py
+timeout 60 mpirun --allow-run-as-root -n 2 yade MPI_lambda.py 2>&1 | tee run.log || true
 
 ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; exit 1; }
 ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; exit 1; }

--- a/tutorials/cases/DEM_UsInterp_solidU/Allrun
+++ b/tutorials/cases/DEM_UsInterp_solidU/Allrun
@@ -7,8 +7,10 @@ setFields
 decomposePar
 mkdir -p spheres springs
 
-mpirun --allow-run-as-root -n 2 yade MPI_lambda.py
+mpirun --allow-run-as-root -n 2 yade MPI_lambda.py 2>&1 | tee run.log
 
+grep -q "DEM coupling: active" run.log \
+    || { echo "ERROR: DEM coupling not active — solver built without -DWITH_YADE=1?"; exit 1; }
 ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; exit 1; }
 ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; exit 1; }
 echo "DEM output check passed"

--- a/tutorials/cases/DEM_UsInterp_solidU/Allrun
+++ b/tutorials/cases/DEM_UsInterp_solidU/Allrun
@@ -5,6 +5,10 @@ cp -r 0_orig 0
 blockMesh
 setFields
 decomposePar
-mkdir -p spheres
+mkdir -p spheres springs
 
 mpirun --allow-run-as-root -n 2 yade MPI_lambda.py
+
+ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; exit 1; }
+ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; exit 1; }
+echo "DEM output check passed"

--- a/tutorials/cases/DEM_UsInterp_solidU/Allrun
+++ b/tutorials/cases/DEM_UsInterp_solidU/Allrun
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Requires a Yade-enabled solver build: ./build.sh --yade
 
 cp -r 0_orig 0
 blockMesh

--- a/tutorials/cases/DEM_UsInterp_solidU/MPI_lambda.py
+++ b/tutorials/cases/DEM_UsInterp_solidU/MPI_lambda.py
@@ -22,7 +22,7 @@ for a in dir(mp):
  """
 #print("YADE: current working directory:", os.getcwd())
 
-writeInterval = 0.1   # seconds ( = OpenFOAM writeInterval controlDict )
+writeInterval = 0.1   # seconds — Yade VTK write interval (separate from OF writeInterval)
 
 
 spring_frame_number = 0
@@ -338,9 +338,11 @@ def printAndSaveDtInfo():
     if mp.rank == 0:
         #print(msg)
 
-        # save to file
-        with open("dtInfo.txt", "w") as f:
-            f.write("iter time yadeDt foamDt ratio\n")
+        # append so all write points are preserved across iterations
+        write_header = not os.path.exists("dtInfo.txt")
+        with open("dtInfo.txt", "a") as f:
+            if write_header:
+                f.write("iter time yadeDt foamDt ratio\n")
             f.write(f"{O.iter} {O.time:.6e} {yadeDt:.6e} {foamDt:.6e} {ratio:.6f}\n")
 
 
@@ -681,8 +683,8 @@ O.engines = [
         NewtonIntegrator(damping=0.99, label='newton', gravity=(0, 0.0, 0)),
         
         PyRunner(command='apply_spring_forces()', iterPeriod=20, firstIterRun=1),
-        PyRunner(command="export_springs()", iterPeriod=timeRatio), # i works!
-        PyRunner(command="export_spheres()", iterPeriod=timeRatio),
+        PyRunner(command="export_springs()", iterPeriod=timeRatio, firstIterRun=1),
+        PyRunner(command="export_spheres()", iterPeriod=timeRatio, firstIterRun=1),
 
         #PyRunner(command='printlambdaDotNew()', iterPeriod=1), #it works! prints a list of sphereID and lambdaDot 
         #VTKRecorder(fileName='spheres/vtk-', recorders=['spheres'], parallelMode=True, virtPeriod=1e-3),

--- a/tutorials/cases/DEM_UsInterp_solidU/MPI_lambda.py
+++ b/tutorials/cases/DEM_UsInterp_solidU/MPI_lambda.py
@@ -54,7 +54,7 @@ O.periodic = False # if true, define O.cell.setBox
 numspheres = 100
 young = 25e6 #5e6
 density = 1200
-NSTEPS = 2000000 #int(2e5)
+NSTEPS = 200  # diagnostic short run — restore to 2000000 for production
 
 O.materials.append(FrictMat(young=young, poisson=0.5, frictionAngle=radians(15), density=density, label='spheremat'))
 O.materials.append(FrictMat(young=young * 100, poisson=0.5, frictionAngle=0, density=0, label='wallmat'))

--- a/tutorials/cases/DEM_UsInterp_solidU/MPI_lambda.py
+++ b/tutorials/cases/DEM_UsInterp_solidU/MPI_lambda.py
@@ -54,7 +54,7 @@ O.periodic = False # if true, define O.cell.setBox
 numspheres = 100
 young = 25e6 #5e6
 density = 1200
-NSTEPS = 200  # diagnostic short run — restore to 2000000 for production
+NSTEPS = 2000000
 
 O.materials.append(FrictMat(young=young, poisson=0.5, frictionAngle=radians(15), density=density, label='spheremat'))
 O.materials.append(FrictMat(young=young * 100, poisson=0.5, frictionAngle=0, density=0, label='wallmat'))

--- a/tutorials/cases/DEM_UsInterp_solidU/MPI_lambda.py
+++ b/tutorials/cases/DEM_UsInterp_solidU/MPI_lambda.py
@@ -54,7 +54,7 @@ O.periodic = False # if true, define O.cell.setBox
 numspheres = 100
 young = 25e6 #5e6
 density = 1200
-NSTEPS = 2000000
+NSTEPS = int(os.environ.get('YADE_NSTEPS', 2000000))
 
 O.materials.append(FrictMat(young=young, poisson=0.5, frictionAngle=radians(15), density=density, label='spheremat'))
 O.materials.append(FrictMat(young=young * 100, poisson=0.5, frictionAngle=0, density=0, label='wallmat'))

--- a/tutorials/cases/DEM_UsInterp_solidU/dtInfo.txt
+++ b/tutorials/cases/DEM_UsInterp_solidU/dtInfo.txt
@@ -1,2 +1,0 @@
-iter time yadeDt foamDt ratio
-1 5.000000e-06 5.000000e-06 1.440127e-07 0.028803

--- a/tutorials/cases/DEM_UsInterp_solidU/system/controlDict
+++ b/tutorials/cases/DEM_UsInterp_solidU/system/controlDict
@@ -23,7 +23,7 @@ startTime       0;
 
 stopAt          endTime;
 
-endTime         10;
+endTime         0.002;  // diagnostic short run — restore to 10 for production
 
 deltaT          1e-7;
 

--- a/tutorials/cases/DEM_UsInterp_solidU/system/controlDict
+++ b/tutorials/cases/DEM_UsInterp_solidU/system/controlDict
@@ -23,7 +23,7 @@ startTime       0;
 
 stopAt          endTime;
 
-endTime         0.002;  // diagnostic short run — restore to 10 for production
+endTime         10;
 
 deltaT          1e-7;
 

--- a/tutorials/cases/DEM_UsInterp_solidU_test2/Allclean
+++ b/tutorials/cases/DEM_UsInterp_solidU_test2/Allclean
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-rm -rf -- processor* 0 0.[1-9]* [1-9]* log log.analyzed postProcessing constant/polyMesh dynamicCode log* spheres/* springs/*
+rm -rf -- processor* 0 0.[1-9]* [1-9]* log log.analyzed postProcessing constant/polyMesh dynamicCode log* spheres/* springs/* dtInfo.txt run.log

--- a/tutorials/cases/DEM_UsInterp_solidU_test2/Allrun
+++ b/tutorials/cases/DEM_UsInterp_solidU_test2/Allrun
@@ -10,8 +10,10 @@ mkdir -p spheres springs
 NSTEPS="${YADE_NSTEPS:-2000000}"
 TIMEOUT="${YADE_TIMEOUT:-3600}"
 echo "  running DEM simulation (NSTEPS=$NSTEPS, timeout=${TIMEOUT}s)..."
-timeout "$TIMEOUT" mpirun --allow-run-as-root -n 2 yade MPI_lambda.py > run.log 2>&1 \
-    || { echo "ERROR: simulation failed or timed out — check run.log"; exit 1; }
+timeout "$TIMEOUT" mpirun --allow-run-as-root -n 2 yade MPI_lambda.py > run.log 2>&1 || true
+pkill -f "porousGasificationFoam" 2>/dev/null || true
+grep -q "RUN FINISH" run.log \
+    || { echo "ERROR: simulation did not complete — check run.log"; exit 1; }
 
 grep -q "DEM coupling: active" run.log \
     || { echo "ERROR: DEM coupling not active — solver built without -DWITH_YADE=1?"; exit 1; }

--- a/tutorials/cases/DEM_UsInterp_solidU_test2/Allrun
+++ b/tutorials/cases/DEM_UsInterp_solidU_test2/Allrun
@@ -6,31 +6,4 @@ blockMesh   > /dev/null 2>&1
 setFields   > /dev/null 2>&1
 decomposePar > /dev/null 2>&1
 mkdir -p spheres springs
-
-NSTEPS="${YADE_NSTEPS:-2000000}"
-TIMEOUT="${YADE_TIMEOUT:-3600}"
-echo "  running DEM simulation (NSTEPS=$NSTEPS, timeout=${TIMEOUT}s)..."
-timeout "$TIMEOUT" mpirun --allow-run-as-root -n 2 yade MPI_lambda.py > run.log 2>&1 || true
-pkill -f "porousGasificationFoam" 2>/dev/null || true
-grep -q "RUN FINISH" run.log \
-    || { echo "ERROR: simulation did not complete — check run.log"; exit 1; }
-
-grep -q "DEM coupling: active" run.log \
-    || { echo "ERROR: DEM coupling not active — solver built without -DWITH_YADE=1?"; exit 1; }
-ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; exit 1; }
-ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; exit 1; }
-echo "  DEM output check passed"
-
-[ -f dtInfo.txt ] \
-    || { echo "ERROR: dtInfo.txt not written — did the run reach iter 1?"; exit 1; }
-if ! python3 - <<'PYCHECK'
-import sys
-lines = [l for l in open("dtInfo.txt") if not l.startswith("iter") and l.strip()]
-if not lines:
-    print("ERROR: dtInfo.txt empty — coupling did not reach iter 1"); sys.exit(1)
-foamDt = float(lines[0].split()[3])
-if foamDt <= 0.0:
-    print("ERROR: foamDt={:.3e} — PGF time step not received".format(foamDt)); sys.exit(1)
-print("  PGF coupling check passed (foamDt={:.3e})".format(foamDt))
-PYCHECK
-then exit 1; fi
+mpirun --allow-run-as-root -n 2 yade MPI_lambda.py

--- a/tutorials/cases/DEM_UsInterp_solidU_test2/Allrun
+++ b/tutorials/cases/DEM_UsInterp_solidU_test2/Allrun
@@ -14,3 +14,17 @@ grep -q "DEM coupling: active" run.log \
 ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; exit 1; }
 ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; exit 1; }
 echo "DEM output check passed"
+
+[ -f dtInfo.txt ] \
+    || { echo "ERROR: dtInfo.txt not written — did the run reach iter 1?"; exit 1; }
+if ! python3 - <<'PYCHECK'
+import sys
+lines = [l for l in open("dtInfo.txt") if not l.startswith("iter") and l.strip()]
+if not lines:
+    print("ERROR: dtInfo.txt empty — coupling did not reach iter 1"); sys.exit(1)
+foamDt = float(lines[0].split()[3])
+if foamDt <= 0.0:
+    print("ERROR: foamDt={:.3e} — PGF time step not received".format(foamDt)); sys.exit(1)
+print("PGF coupling check passed (foamDt={:.3e})".format(foamDt))
+PYCHECK
+then exit 1; fi

--- a/tutorials/cases/DEM_UsInterp_solidU_test2/Allrun
+++ b/tutorials/cases/DEM_UsInterp_solidU_test2/Allrun
@@ -2,18 +2,22 @@
 # Requires a Yade-enabled solver build: ./build.sh --yade
 
 cp -r 0_orig 0
-blockMesh
-setFields
-decomposePar
+blockMesh   > /dev/null 2>&1
+setFields   > /dev/null 2>&1
+decomposePar > /dev/null 2>&1
 mkdir -p spheres springs
 
-mpirun --allow-run-as-root -n 2 yade MPI_lambda.py 2>&1 | tee run.log
+NSTEPS="${YADE_NSTEPS:-2000000}"
+TIMEOUT="${YADE_TIMEOUT:-3600}"
+echo "  running DEM simulation (NSTEPS=$NSTEPS, timeout=${TIMEOUT}s)..."
+timeout "$TIMEOUT" mpirun --allow-run-as-root -n 2 yade MPI_lambda.py > run.log 2>&1 \
+    || { echo "ERROR: simulation failed or timed out — check run.log"; exit 1; }
 
 grep -q "DEM coupling: active" run.log \
     || { echo "ERROR: DEM coupling not active — solver built without -DWITH_YADE=1?"; exit 1; }
 ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; exit 1; }
 ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; exit 1; }
-echo "DEM output check passed"
+echo "  DEM output check passed"
 
 [ -f dtInfo.txt ] \
     || { echo "ERROR: dtInfo.txt not written — did the run reach iter 1?"; exit 1; }
@@ -25,6 +29,6 @@ if not lines:
 foamDt = float(lines[0].split()[3])
 if foamDt <= 0.0:
     print("ERROR: foamDt={:.3e} — PGF time step not received".format(foamDt)); sys.exit(1)
-print("PGF coupling check passed (foamDt={:.3e})".format(foamDt))
+print("  PGF coupling check passed (foamDt={:.3e})".format(foamDt))
 PYCHECK
 then exit 1; fi

--- a/tutorials/cases/DEM_UsInterp_solidU_test2/Allrun
+++ b/tutorials/cases/DEM_UsInterp_solidU_test2/Allrun
@@ -7,8 +7,10 @@ setFields
 decomposePar
 mkdir -p spheres springs
 
-mpirun --allow-run-as-root -n 2 yade MPI_lambda.py
+mpirun --allow-run-as-root -n 2 yade MPI_lambda.py 2>&1 | tee run.log
 
+grep -q "DEM coupling: active" run.log \
+    || { echo "ERROR: DEM coupling not active — solver built without -DWITH_YADE=1?"; exit 1; }
 ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; exit 1; }
 ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; exit 1; }
 echo "DEM output check passed"

--- a/tutorials/cases/DEM_UsInterp_solidU_test2/Allrun
+++ b/tutorials/cases/DEM_UsInterp_solidU_test2/Allrun
@@ -5,6 +5,10 @@ cp -r 0_orig 0
 blockMesh
 setFields
 decomposePar
-mkdir -p spheres
+mkdir -p spheres springs
 
 mpirun --allow-run-as-root -n 2 yade MPI_lambda.py
+
+ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; exit 1; }
+ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; exit 1; }
+echo "DEM output check passed"

--- a/tutorials/cases/DEM_UsInterp_solidU_test2/Allrun
+++ b/tutorials/cases/DEM_UsInterp_solidU_test2/Allrun
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Requires a Yade-enabled solver build: ./build.sh --yade
 
 cp -r 0_orig 0
 blockMesh

--- a/tutorials/cases/DEM_UsInterp_solidU_test2/MPI_lambda.py
+++ b/tutorials/cases/DEM_UsInterp_solidU_test2/MPI_lambda.py
@@ -22,7 +22,7 @@ for a in dir(mp):
  """
 #print("YADE: current working directory:", os.getcwd())
 
-writeInterval = 0.1   # seconds ( = OpenFOAM writeInterval controlDict )
+writeInterval = 0.1   # seconds — Yade VTK write interval (separate from OF writeInterval)
 
 
 spring_frame_number = 0
@@ -338,9 +338,11 @@ def printAndSaveDtInfo():
     if mp.rank == 0:
         #print(msg)
 
-        # save to file
-        with open("dtInfo.txt", "w") as f:
-            f.write("iter time yadeDt foamDt ratio\n")
+        # append so all write points are preserved across iterations
+        write_header = not os.path.exists("dtInfo.txt")
+        with open("dtInfo.txt", "a") as f:
+            if write_header:
+                f.write("iter time yadeDt foamDt ratio\n")
             f.write(f"{O.iter} {O.time:.6e} {yadeDt:.6e} {foamDt:.6e} {ratio:.6f}\n")
 
 
@@ -681,8 +683,8 @@ O.engines = [
         NewtonIntegrator(damping=0.99, label='newton', gravity=(0, 0.0, 0)),
         
         PyRunner(command='apply_spring_forces()', iterPeriod=20, firstIterRun=1),
-        PyRunner(command="export_springs()", iterPeriod=timeRatio), # i works!
-        PyRunner(command="export_spheres()", iterPeriod=timeRatio),
+        PyRunner(command="export_springs()", iterPeriod=timeRatio, firstIterRun=1),
+        PyRunner(command="export_spheres()", iterPeriod=timeRatio, firstIterRun=1),
 
         #PyRunner(command='printlambdaDotNew()', iterPeriod=1), #it works! prints a list of sphereID and lambdaDot 
         #VTKRecorder(fileName='spheres/vtk-', recorders=['spheres'], parallelMode=True, virtPeriod=1e-3),

--- a/tutorials/cases/DEM_UsInterp_solidU_test2/MPI_lambda.py
+++ b/tutorials/cases/DEM_UsInterp_solidU_test2/MPI_lambda.py
@@ -54,7 +54,7 @@ O.periodic = False # if true, define O.cell.setBox
 numspheres = 100
 young = 25e6 #5e6
 density = 1200
-NSTEPS = 2000000 #int(2e5)
+NSTEPS = int(os.environ.get('YADE_NSTEPS', 2000000))
 
 O.materials.append(FrictMat(young=young, poisson=0.5, frictionAngle=radians(15), density=density, label='spheremat'))
 O.materials.append(FrictMat(young=young * 100, poisson=0.5, frictionAngle=0, density=0, label='wallmat'))

--- a/tutorials/cases/DEM_UsInterp_solidU_test2/dtInfo.txt
+++ b/tutorials/cases/DEM_UsInterp_solidU_test2/dtInfo.txt
@@ -1,2 +1,0 @@
-iter time yadeDt foamDt ratio
-1 5.000000e-06 5.000000e-06 1.200480e-04 24.009604

--- a/tutorials/cases/MicroTGA-DEM_Us_UsInterp/Allclean
+++ b/tutorials/cases/MicroTGA-DEM_Us_UsInterp/Allclean
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-rm -rf -- processor* 0 0.[1-9]* [1-9]* log log.analyzed postProcessing constant/polyMesh dynamicCode log* spheres/* springs/*
+rm -rf -- processor* 0 0.[1-9]* [1-9]* log log.analyzed postProcessing constant/polyMesh dynamicCode log* spheres/* springs/* dtInfo.txt run.log

--- a/tutorials/cases/MicroTGA-DEM_Us_UsInterp/Allrun
+++ b/tutorials/cases/MicroTGA-DEM_Us_UsInterp/Allrun
@@ -10,8 +10,10 @@ mkdir -p spheres springs
 NSTEPS="${YADE_NSTEPS:-2000000}"
 TIMEOUT="${YADE_TIMEOUT:-3600}"
 echo "  running DEM simulation (NSTEPS=$NSTEPS, timeout=${TIMEOUT}s)..."
-timeout "$TIMEOUT" mpirun --allow-run-as-root -n 2 yade MPI_lambda.py > run.log 2>&1 \
-    || { echo "ERROR: simulation failed or timed out — check run.log"; exit 1; }
+timeout "$TIMEOUT" mpirun --allow-run-as-root -n 2 yade MPI_lambda.py > run.log 2>&1 || true
+pkill -f "porousGasificationFoam" 2>/dev/null || true
+grep -q "RUN FINISH" run.log \
+    || { echo "ERROR: simulation did not complete — check run.log"; exit 1; }
 
 grep -q "DEM coupling: active" run.log \
     || { echo "ERROR: DEM coupling not active — solver built without -DWITH_YADE=1?"; exit 1; }

--- a/tutorials/cases/MicroTGA-DEM_Us_UsInterp/Allrun
+++ b/tutorials/cases/MicroTGA-DEM_Us_UsInterp/Allrun
@@ -5,6 +5,10 @@ blockMesh
 cp -r 0_orig 0
 setFields
 decomposePar
-mkdir -p spheres
+mkdir -p spheres springs
 
 mpirun --allow-run-as-root -n 2 yade MPI_lambda.py
+
+ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; exit 1; }
+ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; exit 1; }
+echo "DEM output check passed"

--- a/tutorials/cases/MicroTGA-DEM_Us_UsInterp/Allrun
+++ b/tutorials/cases/MicroTGA-DEM_Us_UsInterp/Allrun
@@ -14,3 +14,17 @@ grep -q "DEM coupling: active" run.log \
 ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; exit 1; }
 ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; exit 1; }
 echo "DEM output check passed"
+
+[ -f dtInfo.txt ] \
+    || { echo "ERROR: dtInfo.txt not written — did the run reach iter 1?"; exit 1; }
+if ! python3 - <<'PYCHECK'
+import sys
+lines = [l for l in open("dtInfo.txt") if not l.startswith("iter") and l.strip()]
+if not lines:
+    print("ERROR: dtInfo.txt empty — coupling did not reach iter 1"); sys.exit(1)
+foamDt = float(lines[0].split()[3])
+if foamDt <= 0.0:
+    print("ERROR: foamDt={:.3e} — PGF time step not received".format(foamDt)); sys.exit(1)
+print("PGF coupling check passed (foamDt={:.3e})".format(foamDt))
+PYCHECK
+then exit 1; fi

--- a/tutorials/cases/MicroTGA-DEM_Us_UsInterp/Allrun
+++ b/tutorials/cases/MicroTGA-DEM_Us_UsInterp/Allrun
@@ -6,31 +6,4 @@ cp -r 0_orig 0
 setFields   > /dev/null 2>&1
 decomposePar > /dev/null 2>&1
 mkdir -p spheres springs
-
-NSTEPS="${YADE_NSTEPS:-2000000}"
-TIMEOUT="${YADE_TIMEOUT:-3600}"
-echo "  running DEM simulation (NSTEPS=$NSTEPS, timeout=${TIMEOUT}s)..."
-timeout "$TIMEOUT" mpirun --allow-run-as-root -n 2 yade MPI_lambda.py > run.log 2>&1 || true
-pkill -f "porousGasificationFoam" 2>/dev/null || true
-grep -q "RUN FINISH" run.log \
-    || { echo "ERROR: simulation did not complete — check run.log"; exit 1; }
-
-grep -q "DEM coupling: active" run.log \
-    || { echo "ERROR: DEM coupling not active — solver built without -DWITH_YADE=1?"; exit 1; }
-ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; exit 1; }
-ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; exit 1; }
-echo "  DEM output check passed"
-
-[ -f dtInfo.txt ] \
-    || { echo "ERROR: dtInfo.txt not written — did the run reach iter 1?"; exit 1; }
-if ! python3 - <<'PYCHECK'
-import sys
-lines = [l for l in open("dtInfo.txt") if not l.startswith("iter") and l.strip()]
-if not lines:
-    print("ERROR: dtInfo.txt empty — coupling did not reach iter 1"); sys.exit(1)
-foamDt = float(lines[0].split()[3])
-if foamDt <= 0.0:
-    print("ERROR: foamDt={:.3e} — PGF time step not received".format(foamDt)); sys.exit(1)
-print("  PGF coupling check passed (foamDt={:.3e})".format(foamDt))
-PYCHECK
-then exit 1; fi
+mpirun --allow-run-as-root -n 2 yade MPI_lambda.py

--- a/tutorials/cases/MicroTGA-DEM_Us_UsInterp/Allrun
+++ b/tutorials/cases/MicroTGA-DEM_Us_UsInterp/Allrun
@@ -7,8 +7,10 @@ setFields
 decomposePar
 mkdir -p spheres springs
 
-mpirun --allow-run-as-root -n 2 yade MPI_lambda.py
+mpirun --allow-run-as-root -n 2 yade MPI_lambda.py 2>&1 | tee run.log
 
+grep -q "DEM coupling: active" run.log \
+    || { echo "ERROR: DEM coupling not active — solver built without -DWITH_YADE=1?"; exit 1; }
 ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; exit 1; }
 ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; exit 1; }
 echo "DEM output check passed"

--- a/tutorials/cases/MicroTGA-DEM_Us_UsInterp/Allrun
+++ b/tutorials/cases/MicroTGA-DEM_Us_UsInterp/Allrun
@@ -1,19 +1,23 @@
 #!/bin/bash
 # Requires a Yade-enabled solver build: ./build.sh --yade
-blockMesh
+blockMesh   > /dev/null 2>&1
 
 cp -r 0_orig 0
-setFields
-decomposePar
+setFields   > /dev/null 2>&1
+decomposePar > /dev/null 2>&1
 mkdir -p spheres springs
 
-mpirun --allow-run-as-root -n 2 yade MPI_lambda.py 2>&1 | tee run.log
+NSTEPS="${YADE_NSTEPS:-2000000}"
+TIMEOUT="${YADE_TIMEOUT:-3600}"
+echo "  running DEM simulation (NSTEPS=$NSTEPS, timeout=${TIMEOUT}s)..."
+timeout "$TIMEOUT" mpirun --allow-run-as-root -n 2 yade MPI_lambda.py > run.log 2>&1 \
+    || { echo "ERROR: simulation failed or timed out — check run.log"; exit 1; }
 
 grep -q "DEM coupling: active" run.log \
     || { echo "ERROR: DEM coupling not active — solver built without -DWITH_YADE=1?"; exit 1; }
 ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; exit 1; }
 ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; exit 1; }
-echo "DEM output check passed"
+echo "  DEM output check passed"
 
 [ -f dtInfo.txt ] \
     || { echo "ERROR: dtInfo.txt not written — did the run reach iter 1?"; exit 1; }
@@ -25,6 +29,6 @@ if not lines:
 foamDt = float(lines[0].split()[3])
 if foamDt <= 0.0:
     print("ERROR: foamDt={:.3e} — PGF time step not received".format(foamDt)); sys.exit(1)
-print("PGF coupling check passed (foamDt={:.3e})".format(foamDt))
+print("  PGF coupling check passed (foamDt={:.3e})".format(foamDt))
 PYCHECK
 then exit 1; fi

--- a/tutorials/cases/MicroTGA-DEM_Us_UsInterp/Allrun
+++ b/tutorials/cases/MicroTGA-DEM_Us_UsInterp/Allrun
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Requires a Yade-enabled solver build: ./build.sh --yade
 blockMesh
 
 cp -r 0_orig 0

--- a/tutorials/cases/MicroTGA-DEM_Us_UsInterp/MPI_lambda.py
+++ b/tutorials/cases/MicroTGA-DEM_Us_UsInterp/MPI_lambda.py
@@ -22,7 +22,7 @@ for a in dir(mp):
  """
 #print("YADE: current working directory:", os.getcwd())
 
-writeInterval = 0.1   # seconds ( = OpenFOAM writeInterval controlDict )
+writeInterval = 0.1   # seconds — Yade VTK write interval (separate from OF writeInterval)
 
 
 spring_frame_number = 0
@@ -338,9 +338,11 @@ def printAndSaveDtInfo():
     if mp.rank == 0:
         #print(msg)
 
-        # save to file
-        with open("dtInfo.txt", "w") as f:
-            f.write("iter time yadeDt foamDt ratio\n")
+        # append so all write points are preserved across iterations
+        write_header = not os.path.exists("dtInfo.txt")
+        with open("dtInfo.txt", "a") as f:
+            if write_header:
+                f.write("iter time yadeDt foamDt ratio\n")
             f.write(f"{O.iter} {O.time:.6e} {yadeDt:.6e} {foamDt:.6e} {ratio:.6f}\n")
 
 
@@ -681,8 +683,8 @@ O.engines = [
         NewtonIntegrator(damping=0.99, label='newton', gravity=(0, 0.0, 0)),
         
         PyRunner(command='apply_spring_forces()', iterPeriod=20, firstIterRun=1),
-        PyRunner(command="export_springs()", iterPeriod=timeRatio), # i works!
-        PyRunner(command="export_spheres()", iterPeriod=timeRatio),
+        PyRunner(command="export_springs()", iterPeriod=timeRatio, firstIterRun=1),
+        PyRunner(command="export_spheres()", iterPeriod=timeRatio, firstIterRun=1),
 
         #PyRunner(command='printlambdaDotNew()', iterPeriod=1), #it works! prints a list of sphereID and lambdaDot 
         #VTKRecorder(fileName='spheres/vtk-', recorders=['spheres'], parallelMode=True, virtPeriod=1e-3),

--- a/tutorials/cases/MicroTGA-DEM_Us_UsInterp/MPI_lambda.py
+++ b/tutorials/cases/MicroTGA-DEM_Us_UsInterp/MPI_lambda.py
@@ -54,7 +54,7 @@ O.periodic = False # if true, define O.cell.setBox
 numspheres = 100
 young = 25e6 #5e6
 density = 1200
-NSTEPS = 2000000 #int(2e5)
+NSTEPS = int(os.environ.get('YADE_NSTEPS', 2000000))
 
 O.materials.append(FrictMat(young=young, poisson=0.5, frictionAngle=radians(15), density=density, label='spheremat'))
 O.materials.append(FrictMat(young=young * 100, poisson=0.5, frictionAngle=0, density=0, label='wallmat'))

--- a/tutorials/cases/MicroTGA-DEM_Us_UsInterp/dtInfo.txt
+++ b/tutorials/cases/MicroTGA-DEM_Us_UsInterp/dtInfo.txt
@@ -1,2 +1,0 @@
-iter time yadeDt foamDt ratio
-1 5.000000e-06 5.000000e-06 1.000000e-06 0.200000


### PR DESCRIPTION
Since \`WITH_YADE\` was introduced to the solver, DEM/Yade coupling has never been
active. The solver compiled and ran silently without error but ignored Yade entirely.
Two independent bugs caused this — both are fixed here. A regression suite covering
all three DEM tutorial cases is added to catch both automatically.

**Bug fixes**

- \`Make/options\`: add \`-DWITH_YADE=1\` to Yade build flags. The coupling code is
  guarded by \`#ifdef WITH_YADE\`; without this flag it compiled out silently even
  when the solver was built with \`./build.sh --yade\`.
- \`volPyrolysis\`: bind \`Us_\` to the shared registered \`Us\` field instead of
  constructing a new local one. Yade writes solid velocity into the registered \`Us\`;
  the solver reads from \`Us_\`. With the broken binding these were two different
  objects — DEM updates never reached the solver.

**Supporting changes**

- \`applications/test/regression/Allrun.yade\` + \`tools/runDEMCase.sh\`: smoke test
  that runs 200 Yade steps per case and checks clean exit (\`RUN FINISH\` in log),
  compiler flag active (\`DEM coupling: active\` in log), VTK files written, and
  \`foamDt > 0\` in \`dtInfo.txt\`. Covers all three DEM tutorial cases.
- Tutorial \`Allrun\` scripts (\`DEM_UsInterp_solidU\`, \`DEM_UsInterp_solidU_test2\`,
  \`MicroTGA-DEM_Us_UsInterp\`): minimal setup + unconditional \`mpirun\`, no test
  harness. Test orchestration (timeout, \`pkill\`, validation) belongs to
  \`tools/runDEMCase.sh\` so tutorial scripts remain usable as production scripts.

**Verified**

- [x] \`./build.sh --yade\` succeeds
- [x] \`applications/test/regression/Allrun.yade --short\` — all 3 DEM cases PASS
- [x] \`applications/test/regression/Allrun\` — \`charOnlyMoveSerial\` PASS (non-Yade build unaffected)