### PR TITLE
Fix/moving between subdomains boundaries

### DIFF
--- a/porousGasificationMedia/pyrolysisModels/pyrolysisModel/volPyrolysis/volPyrolysis.C
+++ b/porousGasificationMedia/pyrolysisModels/pyrolysisModel/volPyrolysis/volPyrolysis.C
@@ -1270,7 +1270,9 @@ void volPyrolysis::evolvePorosity()
         Info<< "; values min Y = " << gMin(por)
             <<" max Y = " << gMax(por) << endl;
 
-        scalar minTs = min(max(gAverage(T_), scalar(200.0)), scalar(6000.0));
+        //scalar minTs = min(max(gAverage(T_), scalar(200.0)), scalar(6000.0));
+        scalar minTs = -1.;
+
 
 
 

--- a/porousGasificationMedia/pyrolysisModels/pyrolysisModel/volPyrolysis/volPyrolysis.C
+++ b/porousGasificationMedia/pyrolysisModels/pyrolysisModel/volPyrolysis/volPyrolysis.C
@@ -1221,8 +1221,10 @@ void volPyrolysis::evolveRegion()
     chemistrySh_ = solidChemistry_->Sh()(); // eqZx2uHGn004
     heatUpGas_ = heatUpGasCalc()();
 
+    //DasteXar changed the order of solving otherwise only porosity moves not Y_ 
+    evolvePorosity();   
     solveSpeciesMass();
-    evolvePorosity();
+    
 
     solidThermo_.correct(); // eqZx2uHGn046
 
@@ -1268,7 +1270,9 @@ void volPyrolysis::evolvePorosity()
         Info<< "; values min Y = " << gMin(por)
             <<" max Y = " << gMax(por) << endl;
 
-        scalar minTs = -1.;
+        scalar minTs = min(max(gAverage(T_), scalar(200.0)), scalar(6000.0));
+
+
 
         FIFOStack<label> flippedStack = {};
 
@@ -1585,11 +1589,27 @@ void volPyrolysis::evolvePorosity()
                                  {
                                      faceID = mesh_.boundaryMesh()[patchID].whichFace(mesh_.cells()[realRoutes[routeI][stepI-1] - minLocalGlobalI][faceI]);
                                      if (isA<processorPolyPatch>(mesh_.boundaryMesh()[patchID]))
-                                     {
-                                         scalar cellVolumeRatio = cellVolume_.boundaryField()[patchID].patchNeighbourField()()[faceID]/cellVolume_[realRoutes[routeI][stepI-1] - minLocalGlobalI];
-                                         // this 0.001 is a guardian for too large skewness in cells. It introduces error and will be solved in the future.
-                                         porosity_[realRoutes[routeI][stepI-1] - minLocalGlobalI] = max(1. - (1. - porosity_.boundaryField()[patchID].patchNeighbourField()()[faceID])*cellVolumeRatio
-                                                                                                       ,0.001);
+                                        {
+                                            //DasteXar to pass values from one subdomain to another 
+                                            label neighbourGlobalID =
+                                                globalIndices.boundaryField()[patchID].patchNeighbourField()()[faceID];
+
+                                            if (neighbourGlobalID != realRoutes[routeI][stepI])
+                                            {
+                                                continue;
+                                            }
+
+                                            scalar cellVolumeRatio =
+                                                cellVolume_.boundaryField()[patchID].patchNeighbourField()()[faceID]
+                                            / cellVolume_[realRoutes[routeI][stepI-1] - minLocalGlobalI];
+
+                                            porosity_[realRoutes[routeI][stepI-1] - minLocalGlobalI] =
+                                                max
+                                                (
+                                                    1. - (1. - porosity_.boundaryField()[patchID].patchNeighbourField()()[faceID])
+                                                    * cellVolumeRatio,
+                                                    0.001
+                                                );
                                          porosityArch_[realRoutes[routeI][stepI-1] - minLocalGlobalI] = max(1. - (1. - porosityArch_.boundaryField()[patchID].patchNeighbourField()()[faceID])*cellVolumeRatio
                                                                                                         ,0.001);
                                          T_[realRoutes[routeI][stepI-1] - minLocalGlobalI] = T_.boundaryField()[patchID].patchNeighbourField()()[faceID];

--- a/tutorials/cases/charOnlyMove/constant/pyrolysisProperties
+++ b/tutorials/cases/charOnlyMove/constant/pyrolysisProperties
@@ -22,7 +22,7 @@ heterogeneousPyrolysisModel  volPyrolysis;
 pyrolysisCoeffs
 {
     subintegrateHeatTransfer true;
-    bedCollapse false;
+    bedCollapse true;
     criticalPorosity 0.9999;
     replenish false;
 }

--- a/tutorials/cases/charOnlyMove/system/controlDict
+++ b/tutorials/cases/charOnlyMove/system/controlDict
@@ -17,7 +17,7 @@ FoamFile
 
 application     porousGasificationFoam;
 
-startFrom       latestTime;
+startFrom       startTime;
 
 startTime       0; 
 
@@ -25,7 +25,7 @@ stopAt          endTime;
 
 endTime         10;
 
-deltaT          1e-7;
+deltaT          1e-3;
 
 maxDeltaT	    0.001;
 

--- a/tutorials/cases/charOnlyMove/system/decomposeParDict
+++ b/tutorials/cases/charOnlyMove/system/decomposeParDict
@@ -21,7 +21,7 @@ method            simple;
 
 simpleCoeffs
 {
-    n               (2 1 2);
+    n               (4 1 1);
     delta           0.001;
 }
 

--- a/tutorials/cases/charOnlyMove/system/fvSolution
+++ b/tutorials/cases/charOnlyMove/system/fvSolution
@@ -68,13 +68,25 @@ solvers
         tolerance       1e-12;
         relTol          1e-7;
     }
+    // Ts
+    // {
+    //     solver           PCG;
+    //     preconditioner   DIC;
+    //     tolerance        1e-13;
+    //     relTol           0;
+    // }
+
+
     Ts
-    {
-        solver           PCG;
-        preconditioner   DIC;
-        tolerance        1e-13;
-        relTol           0;
-    }
+{
+    solver          PBiCGStab;
+preconditioner  DIC;
+    tolerance       1e-10;
+    relTol          1e-6;
+    maxIter         1000;
+}
+
+
     rhos
     {
         solver          PBiCG;
@@ -117,6 +129,7 @@ relaxationFactors
         hFinal  1;
         Yi  1;
         YiFinal 1;
+        Ts  0.3;
     }
 }
 

--- a/tutorials/cases/charOnlyMove/system/setFieldsDict
+++ b/tutorials/cases/charOnlyMove/system/setFieldsDict
@@ -17,7 +17,7 @@ FoamFile
 
 defaultFieldValues
 (
-    volScalarFieldValue Ts -1
+    //volScalarFieldValue Ts -1
     volScalarFieldValue porosityF  1. 
     volScalarFieldValue porosityF0 1.
     volScalarFieldValue Yrubberwood  0.
@@ -118,7 +118,7 @@ regions
       box (.0 -0.1 0.025) (0.1 0.1 0.05);
       fieldValues
       (
-          volVectorFieldValue Us (0.01 0 0)
+          volVectorFieldValue Us (0.02 0 0)
       );
   }
 


### PR DESCRIPTION
## Summary
porosityF now cross processors' boundaries 


## Why
The case previously crashed when the moving solid region reached processor boundaries because unstable temperature

## Verification
Re-ran tutorials/cases/charOnlyMove in parallel; the case now runs without crashing, and porosityF moves across decomposed domains.
