### PR TITLE
fix(chemistry): guard solid energy updates against vanishing heat capacity

### DIFF
--- a/porousGasificationMedia/thermophysicalModels/porousSolidChemistryModel/porousSolidChemistryModel/ODESolidHeterogeneousChemistryModel/ODESolidHeterogeneousChemistryModel.C
+++ b/porousGasificationMedia/thermophysicalModels/porousSolidChemistryModel/porousSolidChemistryModel/ODESolidHeterogeneousChemistryModel/ODESolidHeterogeneousChemistryModel.C
@@ -1674,8 +1674,10 @@ Foam::ODESolidHeterogeneousChemistryModel<SolidThermo, SolidThermoType, GasTherm
         }
         else if (newhi != 0)
         {
-            // One-shot diagnostic: confirms the guard fired and reports the
-            // offending cell state. Remove once the fix is validated.
+            // Reports the cell state the first time the guard skips an update,
+            // once per process, so that a run can show whether the state occurs
+            // at all. Solid mass fractions are listed by name over the solids
+            // actually present -- the composition is case-dependent.
             static bool reported = false;
             if (!reported)
             {
@@ -1687,10 +1689,14 @@ Foam::ODESolidHeterogeneousChemistryModel<SolidThermo, SolidThermoType, GasTherm
                     << " solidRho=" << solidRho
                     << " newCp=" << newCp
                     << " newhi=" << newhi
-                    << " Ti=" << Ti
-                    << " Ywood=" << Ys_[0][celli]
-                    << " Ychar=" << Ys_[1][celli]
-                    << endl;
+                    << " Ti=" << Ti;
+
+                forAll(Ys_, i)
+                {
+                    Pout<< ' ' << Ys_[i].name() << '=' << Ys_[i][celli];
+                }
+
+                Pout<< endl;
             }
         }
 

--- a/porousGasificationMedia/thermophysicalModels/porousSolidChemistryModel/porousSolidChemistryModel/ODESolidHeterogeneousChemistryModel/ODESolidHeterogeneousChemistryModel.C
+++ b/porousGasificationMedia/thermophysicalModels/porousSolidChemistryModel/porousSolidChemistryModel/ODESolidHeterogeneousChemistryModel/ODESolidHeterogeneousChemistryModel.C
@@ -785,8 +785,21 @@ void Foam::ODESolidHeterogeneousChemistryModel<SolidThermo, SolidThermoType, Gas
         newhi += omegaPreq[nEqns()];
     }
 
-    scalar dTdt = (newhi == 0 ? 0 : newhi/newCp);
-    scalar dtMag = min(500.0, mag(dTdt));
+    // Reaction heating rate of the solid, guarded against a vanishing heat
+    // capacity. newCp is built from the solid concentrations c[i], so it tends
+    // to zero as the solid is consumed; in the branch above that takes newhi
+    // from omegaPreq[nEqns()], newhi does not vanish with it, leaving
+    // newhi/newCp to overflow. The limiter below cannot absorb that: an
+    // infinite dTdt makes the scaling inf/inf, i.e. NaN. Guard the division
+    // instead -- with no solid heat capacity there is no heating rate.
+    scalar dTdt = 0;
+    if (newhi != 0 && newCp > VSMALL)
+    {
+        dTdt = newhi/newCp;
+    }
+
+    // Bound the reaction heating to |dT/dt| <= 500 K/s, preserving its sign.
+    const scalar dtMag = min(500.0, mag(dTdt));
     dcdt[nSpecie_] = dTdt*dtMag/(mag(dTdt) + 1.0e-10);
 
     // dp/dt = ...

--- a/porousGasificationMedia/thermophysicalModels/porousSolidChemistryModel/porousSolidChemistryModel/ODESolidHeterogeneousChemistryModel/ODESolidHeterogeneousChemistryModel.C
+++ b/porousGasificationMedia/thermophysicalModels/porousSolidChemistryModel/porousSolidChemistryModel/ODESolidHeterogeneousChemistryModel/ODESolidHeterogeneousChemistryModel.C
@@ -1657,7 +1657,42 @@ Foam::ODESolidHeterogeneousChemistryModel<SolidThermo, SolidThermoType, GasTherm
             newhi += omegaPreq[nEqns()];
         }
 
-        scalar dTi =  ( newhi == 0 ? 0 : (newhi/(newCp*solidRho))*dt_ );
+        // Solid-phase temperature update. Divides reaction heat by solid heat
+        // capacity. Cells admitted by the permissive reacting-cell criterion
+        // (porosity < 1, see volPyrolysis::preEvolveRegion) can carry a
+        // vanishing solid fraction: solidRho -> 0 drives newCp -> 0 too,
+        // while reaction heat stays finite (computed from mass fractions,
+        // not absolute mass) -> newhi/(newCp*solidRho) overflows to inf/NaN
+        // -> FOAM_SIGFPE. With no solid mass there is no solid temperature
+        // to advance.
+        const scalar solidHeatCapacity = newCp*solidRho;
+
+        scalar dTi = 0;
+        if (newhi != 0 && solidHeatCapacity > VSMALL)
+        {
+            dTi = (newhi/solidHeatCapacity)*dt_;
+        }
+        else if (newhi != 0)
+        {
+            // One-shot diagnostic: confirms the guard fired and reports the
+            // offending cell state. Remove once the fix is validated.
+            static bool reported = false;
+            if (!reported)
+            {
+                reported = true;
+                Pout<< "ODESolidHeterogeneousChemistryModel::calculateSourceTerms:"
+                    << " skipped solid T update (negligible solid heat capacity)"
+                    << " cell=" << celli
+                    << " porosity=" << porosityF_[celli]
+                    << " solidRho=" << solidRho
+                    << " newCp=" << newCp
+                    << " newhi=" << newhi
+                    << " Ti=" << Ti
+                    << " Ywood=" << Ys_[0][celli]
+                    << " Ychar=" << Ys_[1][celli]
+                    << endl;
+            }
+        }
 
         Ti += dTi;
 


### PR DESCRIPTION
## Summary

`ODESolidHeterogeneousChemistryModel` divides reaction heat by the solid heat capacity
in two places without checking that the capacity is non-zero. A cell admitted by the
permissive reacting-cell criterion (porosity < 1, see `volPyrolysis::preEvolveRegion`)
can carry almost no solid mass: `solidRho` and `newCp` both tend to zero while `newhi`
stays finite, being computed from mass fractions rather than absolute mass. The
division overflows to inf/NaN and trips `FOAM_SIGFPE`.

## Verification

**Build.** `build-pgf` compiles every library and the solver with no errors and no new
warnings. The Yade-coupled build was not attempted — it is broken on `main` for
reasons unrelated to this branch.

**Regression.** All 19 cases of the `fast` tier were run to completion and compared
against their committed baselines with `compareScalars.py` (`rtol=1e-4`,
`atol=1e-12`). **All 19 match.** The `convergence` tier was not run.

**The two aborts.** 17 cases exit cleanly. `enthalpy` and `equilibrium` print `End` —
so the time loop finished and all output was written — and then abort during shutdown
while releasing memory. Their results are intact: compared by hand, 5/5 files within
tolerance for each. Unmodified `main`, built and run the same way in the same session,
aborts in the same two cases and passes the same 17. This teardown `SIGABRT` is
pre-existing and intermittent, so the tier's exit status carries no signal about this
branch — only the field-by-field comparison does.

**What the suite does not show.** The condition being guarded never arises in any of
the 19 cases, so the tier shows that this change is inert on ground it covers, not
that the guards are correct when they trigger. For the post-integration guard that is
direct evidence: its diagnostic prints in no run log. The `derivatives()` guard has no
diagnostic, so there the argument is indirect — a division that had overflowed would
have put NaN into the integration and moved the results.
