### PR TITLE
test(regression): add --jobs, machine-readable listing and structured run state

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,9 +424,11 @@ The framework has two runners that share one outcome vocabulary:
 
 - **Serial suite** — `Allrun` / `Allclean`, `cases.list`, `tools/runCase.sh`, `tools/compareScalars.py`.
 - **DEM (Yade) suite** — `Allrun.yade`, `cases_yade.list`, `tools/runDEMCase.sh` (requires a Yade-enabled build; see below).
-- **Shared logic** — `tools/regressionLib.sh` holds the pieces both runners must agree on: how a case list is loaded, how a case's exit status becomes an outcome, and how the summary decides whether the suite is green.
+- **Shared logic** — `tools/regressionLib.sh` holds the pieces both runners must agree on: how a case list is loaded, how a case's exit status becomes an outcome, how the summary decides whether the suite is green, and the bounded-concurrency mechanics. `tools/regressionState.py` serialises run state as JSON (standard library only, no project imports).
 
 Per-case bits live in `tutorials/cases/<caseName>/system/regressionFunctions` (`volFieldValue` blocks included from `controlDict`) and `tutorials/cases/<caseName>/reference/postProcessing/` (committed baseline).
+
+**The suite scripts are self-contained.** They need bash, `python3` and the OpenFOAM environment, and nothing else — no external tool takes part in deciding which cases run, how they are cleaned, what a case's `Allrun` does, how output is compared, or whether the suite is green. Tooling that wants to watch a run reads the optional structured state described below; it is a reader, never a participant. If a helper ever appears to be *required* to run regressions, that is a bug in the helper.
 
 ### Outcome contract
 
@@ -440,7 +442,7 @@ Every case ends in exactly one outcome, keyed off the case's exit status (standa
 | `124` | `TIMEOUT` | no | the run exceeded its timeout and its process group was terminated |
 | `128+N` | `CRASH (SIG…)` | no | the run died on signal N (e.g. `134` → `CRASH (SIGABRT)`, `139` → `CRASH (SIGSEGV)`) |
 
-**The only green suite is one where at least one case ran and every case PASSed.** There is no benign "skip": a case with no reference baseline is an `ERROR`, not a silently-passing skip; an empty or unreadable `cases.list` is an `ERROR`; a run that compared nothing (e.g. a filter that matched no case) is non-zero. A suite that compared nothing can never report success.
+**The only green suite is one where at least one case ran and every case PASSed.** There is no benign "skip": a case with no reference baseline is an `ERROR`, not a silently-passing skip; an empty or unreadable `cases.list` / `cases_yade.list` is an `ERROR`; a `--tag` or `--case` filter that matched no case is an `ERROR` (exit 2), not an empty green run. A suite that compared nothing can never report success. Skip a suite by not invoking its driver, never by emptying its inventory.
 
 ### Tiers
 
@@ -480,25 +482,104 @@ After commit, every subsequent run of `applications/test/regression/Allrun` comp
 
 ```bash
 cd applications/test/regression
-./Allrun                                  # fast tier (default)
+./Allrun                                  # fast tier (default), one case at a time
 ./Allrun --tag all                        # every case regardless of tag
 ./Allrun --case charOnlyMoveCases/serial  # a single case
 ./Allrun --no-run                         # compare existing output only
 ./Allrun --rtol 1e-3                      # override default relative tolerance
+./Allrun --jobs 4                         # four cases at a time (see below)
+./Allrun --list                           # show the selected cases, run nothing
+./Allrun --state-dir /scratch/reg-state   # also write machine-readable run state
 ```
 
 Exit code `0` means every case that ran PASSed; any non-zero means at least one case was not green (FAIL/ERROR/TIMEOUT/CRASH). The summary lists each case with its outcome and, on a FAIL, the rows that diverged; a CRASH shows the signal name so a teardown abort is not mistaken for a numerical divergence.
 
 The solver must be on `PATH` (source the OpenFOAM environment and build the solver first). A run tier that cannot find the solver produces `ERROR`/`CRASH` outcomes, not a false green.
 
+The per-case runners are supported entry points in their own right, for when you want one case without the suite around it:
+
+```bash
+tools/runCase.sh    tutorials/cases/canonical/pyrolysis [--no-run] [--rtol R] [--atol A]
+tools/runDEMCase.sh tutorials/cases/DEM_UsInterp_solidU [--timeout S] [--nsteps N]
+```
+
+Both return the same taxonomy as the suite, and both accept the optional state flags described below.
+
+### Suite concurrency (`--jobs`) is not case decomposition
+
+`--jobs N` is the number of regression **cases** the driver may have in flight at once. It says nothing about MPI: it does not become `-np N`, it does not touch `decomposeParDict`, and it does not change how any case invokes its solver.
+
+Whether a case runs serially, calls `decomposePar`, uses `runParallel`, launches `mpirun` itself, or starts a Yade coupling process is part of the solution procedure being tested, and lives in that case's own `Allrun`. Nothing in the regression framework second-guesses it. Budget cores accordingly: `--jobs 4` over four 2-rank cases wants eight cores.
+
+`--jobs 1` is exactly the default sequential run — same case order, same outcomes, same output. Concurrency changes only three things:
+
+- each case's output is captured to a file instead of streaming live, replayed for failing cases after the run so the diagnostics stay readable and in `cases.list` order;
+- a one-line verdict is printed as each case finishes;
+- with no `--state-dir`, a temporary directory is created for that capture and removed on exit.
+
+A malformed `--jobs` value (zero, negative, non-numeric) is an `ERROR`/exit 2 rather than a silently coerced default.
+
+### Machine-readable listing and run state
+
+Both drivers can describe a selection without touching it, and can record a run as it happens. Both are optional: with neither flag the drivers behave exactly as they always have and write nothing extra.
+
+**Listing.** `--list` prints the selected cases; adding `--json` emits the manifest an external observer needs in order to know what a run of the *same arguments* will do — the filters are applied by one code path, so a listing cannot disagree with the run:
+
+```bash
+./Allrun --list --json --tag fast
+./Allrun.yade --list --json
+```
+
+```json
+{
+  "schema_version": 1, "record": "listing",
+  "suite": "regression", "driver": "Allrun",
+  "project_root": "/path/to/pgf",
+  "cases": [
+    { "id": "tutorials/cases/canonical/pyrolysis", "name": "pyrolysis",
+      "path": "/path/to/pgf/tutorials/cases/canonical/pyrolysis",
+      "runner": "runCase.sh", "tag": "fast" }
+  ]
+}
+```
+
+A case `id` is its `cases.list`-relative path, not its basename, so two cases with the same basename can never be confused. (`cases.list` is whitespace-delimited, so a case path cannot contain spaces — a constraint of the inventory file, not of the protocol.) Listing a missing, empty or unmatched selection exits 2.
+
+**Run state.** `--state-dir DIR` makes the driver record what it is doing, under a directory the caller owns — deliberately outside the cases, so a case's `Allclean` cannot delete the record of the run in progress:
+
+```text
+<state-dir>/
+  suite.json            selection + options for this run
+  events.ndjson         append-only event stream (one JSON object per line)
+  result.json           final suite result, written atomically
+  cases/<case-id>/
+    state.json           current phase
+    events.ndjson        this case's events
+    result.json          this case's terminal result
+    stdout.log, stderr.log
+    compare.log          comparator output (serial suite)
+```
+
+Events are `suite_started`, `case_queued`, `case_started`, `case_phase`, `case_finished`, `suite_finished`; phases are `queued`, `clean`, `run`, `assert`, `compare`. Each terminal result carries the status, the **raw exit code**, the signal number and name for a signal death, timestamps and elapsed time, the phase it failed in, a human-readable message, artifact paths, and the comparator's file counts.
+
+Two invariants make the state trustworthy:
+
+- **The exit code remains the contract.** JSON is an additional representation of the same outcome, never a replacement, and a failed state write never changes a case's result.
+- **An absent result is never a pass.** If a runner dies before writing one, the driver synthesises the outcome from the wait status it actually observed; if a case's own `result.json` disagrees with that status, the observed status wins and the disagreement is recorded (`result_mismatch`), so a stale file from an earlier run cannot turn a crash green.
+
+`foamcli test` is one consumer of this contract — a convenience wrapper that runs `Allrun` and renders its state as a dashboard or JSON. It is optional in both directions: PGF never calls it, and it never decides whether a PGF case passed.
+
 ### DEM (Yade) smoke suite
 
 ```bash
 applications/test/regression/Allrun.yade --short   # fast smoke: YADE_NSTEPS=200
 applications/test/regression/Allrun.yade           # full run (hours)
+applications/test/regression/Allrun.yade --list    # selected DEM cases, run nothing
 ```
 
 Requires a Yade-enabled solver build (`./build.sh --yade` / `build-pgf --yade`), Yade, and `mpirun`. `--short` caps each case to a few hundred coupling steps so it runs in seconds and checks the coupling handshake and output rather than a converged result; a `YADE_NSTEPS`/`YADE_TIMEOUT` preset in the environment overrides the `--short` defaults. Each case is validated for `RUN FINISH`, an active DEM coupling handshake, sphere/spring VTK output, and a positive PGF time step in `dtInfo.txt`.
+
+The DEM driver takes the same `--list`/`--json`/`--state-dir` flags as the serial one, and the same `--jobs N` — but it defaults to **one** case at a time and warns when you raise it, because concurrent DEM execution has not been verified: each case spawns its own `mpirun` → Yade → `MPI_Comm_spawn`'d solver tree, so two at once oversubscribe the machine in a way a serial case does not.
 
 A hung DEM run is bounded by `YADE_TIMEOUT` and terminated by signalling **only its own process group** (`setsid` + `timeout --kill-after`) — the whole tree of `mpirun` → `yade` → the `MPI_Comm_spawn`'d solver. The runner never issues a host-wide `pkill`, which would kill unrelated solver runs elsewhere on the machine. `cases_yade.list` is the DEM inventory (kept separate from the serial `cases.list`).
 

--- a/applications/test/regression/Allrun
+++ b/applications/test/regression/Allrun
@@ -3,6 +3,13 @@
 # Iterates the case paths listed in cases.list, runs each case, then diffs
 # postProcessing/ output against the committed reference/ baseline.
 #
+# This script is the authority on the serial regression suite: which cases
+# belong to it, how they are filtered, in what order and how many at a time they
+# run, and whether the suite as a whole is green. It needs nothing but bash,
+# python3 and the OpenFOAM environment — no external tool participates in the
+# decision. An observer (CI, a TUI, `foamcli test`) may read the optional
+# structured run state written under --state-dir, but only ever as a reader.
+#
 # Verified against:
 #   gitlab.com/openfoam/core/openfoam : tutorials use Allrun + RunFunctions.
 #   gitlab.com/openfoam/core/openfoam/.../FOvolFieldValue : functionObject syntax.
@@ -13,20 +20,26 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 # Shared runner logic (case loading, outcome classification, summary + honest
-# exit). The library sources helpers.sh, absorbing the set +u include-guard
-# dance, so this driver sources only the library.
+# exit, run-state serialisation). The library sources helpers.sh, absorbing the
+# set +u include-guard dance, so this driver sources only the library.
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/tools/regressionLib.sh"
 
 CASES_FILE="$SCRIPT_DIR/cases.list"
 COMPARE="$SCRIPT_DIR/tools/compareScalars.py"
 RUN_CASE="$SCRIPT_DIR/tools/runCase.sh"
+SUITE_ID="regression"
+DRIVER="Allrun"
 
 RTOL="1e-4"
 ATOL="1e-12"
 ONLY_CASE=""
 SKIP_RUN=false
 TAG="fast"
+JOBS=1
+LIST_ONLY=false
+AS_JSON=false
+STATE_DIR=""
 
 usage() {
     cat <<EOF
@@ -40,6 +53,13 @@ Options:
   --atol <val>    Absolute tolerance for compareScalars.py (default 1e-12).
   --no-run        Skip running cases; only compare existing postProcessing/
                   output to reference/.
+  --jobs <n>      Number of regression CASES to run concurrently (default 1).
+                  This is suite concurrency only: it never changes how a case
+                  decomposes or how many MPI ranks its own Allrun uses.
+  --list          List the selected cases and exit without touching them.
+  --json          With --list, emit the machine-readable case manifest.
+  --state-dir <d> Write structured run state (suite.json, events.ndjson,
+                  result.json, cases/<id>/…) into <d> for an external observer.
   -h, --help      Show this help.
 
 Tags defined in cases.list:
@@ -55,10 +75,21 @@ while [ $# -gt 0 ]; do
         --rtol) RTOL="$2";      shift 2 ;;
         --atol) ATOL="$2";      shift 2 ;;
         --no-run) SKIP_RUN=true; shift ;;
+        --jobs|-j) JOBS="$2";   shift 2 ;;
+        --list) LIST_ONLY=true; shift ;;
+        --json) AS_JSON=true;   shift ;;
+        --state-dir) STATE_DIR="$2"; shift 2 ;;
         -h|--help) usage; exit 0 ;;
         *) clog ERROR "Unknown option: $1"; usage; exit 2 ;;
     esac
 done
+
+# A malformed job count is an infrastructure error, not something to guess at:
+# silently coercing it could turn a typo into an unbounded fork storm.
+if ! [[ "$JOBS" =~ ^[0-9]+$ ]] || [ "$JOBS" -lt 1 ]; then
+    clog ERROR "--jobs must be a positive integer (got: $JOBS)"
+    exit 2
+fi
 
 # Load the registered suite. An empty or unreadable suite is an ERROR, never
 # green — a gate that compares nothing must not report success.
@@ -67,68 +98,348 @@ if ! reg_load_cases "$CASES_FILE" CASE_LINES; then
     exit 2
 fi
 
+# -- selection ----------------------------------------------------------------
+#
+# One implementation of the filter rules, used by both --list and the run paths,
+# so a listing can never disagree with what a run of the same arguments does.
+
+SEL_IDS=()
+SEL_TAGS=()
+
+select_cases() {
+    local line caseRel caseTag
+    for line in "${CASE_LINES[@]}"; do
+        caseRel=$(awk '{print $1}' <<< "$line")
+        caseTag=$(awk '{print $2}' <<< "$line")
+        [ -z "$caseTag" ] && caseTag="fast"
+
+        # Tag filter (skip unless --tag all or tag matches).
+        if [ "$TAG" != "all" ] && [ "$caseTag" != "$TAG" ]; then
+            continue
+        fi
+
+        # --case filter: accepts the basename or the cases.list path.
+        if [ -n "$ONLY_CASE" ] && \
+           [ "$(basename "$caseRel")" != "$ONLY_CASE" ] && \
+           [ "$caseRel" != "$ONLY_CASE" ]; then
+            continue
+        fi
+
+        SEL_IDS+=("$caseRel")
+        SEL_TAGS+=("$caseTag")
+    done
+}
+
+select_cases
+
+# A selection that matched nothing is an ERROR: a gate that compares nothing
+# must not report success, and must not be mistaken for an empty suite either.
+if [ "${#SEL_IDS[@]}" -eq 0 ]; then
+    clog ERROR "no case in $CASES_FILE matches tag '$TAG'${ONLY_CASE:+ and case '$ONLY_CASE'} (nothing to compare)"
+    exit 2
+fi
+
+# reg_case_args <array-name> — append the per-case --case-id/--case-tag pairs
+#   that regressionState.py zips back into a manifest.
+listing_args() {
+    local -n _out="$1"
+    local i
+    for i in "${!SEL_IDS[@]}"; do
+        _out+=(--case-id "${SEL_IDS[$i]}" --case-tag "${SEL_TAGS[$i]}")
+    done
+}
+
+# -- listing mode -------------------------------------------------------------
+
+if [ "$LIST_ONLY" = true ]; then
+    if [ "$AS_JSON" = true ]; then
+        args=(listing --suite "$SUITE_ID" --driver "$DRIVER"
+              --project-root "$REPO_ROOT" --runner "$(basename "$RUN_CASE")"
+              --field "tag=$TAG" --int "jobs=$JOBS" --bool "no_run=$SKIP_RUN"
+              --field "rtol=$RTOL" --field "atol=$ATOL")
+        [ -n "$ONLY_CASE" ] && args+=(--field "case_filter=$ONLY_CASE")
+        listing_args args
+        exec python3 "$REG_STATE_PY" "${args[@]}"
+    fi
+    clog INFO "suite $SUITE_ID — ${#SEL_IDS[@]} case(s) selected (tag: $TAG)"
+    for i in "${!SEL_IDS[@]}"; do
+        printf '  %-8s %s\n' "${SEL_TAGS[$i]}" "${SEL_IDS[$i]}"
+    done
+    exit 0
+fi
+
+if [ "$AS_JSON" = true ]; then
+    clog ERROR "--json is only meaningful with --list; run state goes to --state-dir"
+    exit 2
+fi
+
+# -- run-state / output-capture setup ----------------------------------------
+#
+# SCHED_DIR is where per-case bookkeeping lives. With --state-dir it is the
+# caller's directory and survives the run; with --jobs > 1 and no --state-dir a
+# throwaway one is created purely so concurrent cases do not interleave their
+# output, and is removed on exit. With neither (the default single-job run) there
+# is no bookkeeping at all and the case output streams straight to the terminal,
+# exactly as it always has.
+
+SCHED_DIR=""
+CASES_ROOT=""
+SUITE_EVENTS=""
+STATE_ACTIVE=false
+TEMP_SCHED_DIR=""
+
+if [ -n "$STATE_DIR" ]; then
+    if ! mkdir -p "$STATE_DIR"; then
+        clog ERROR "cannot create state directory: $STATE_DIR"
+        exit 2
+    fi
+    SCHED_DIR="$(cd "$STATE_DIR" && pwd)"
+    STATE_ACTIVE=true
+    SUITE_EVENTS="$SCHED_DIR/events.ndjson"
+elif [ "$JOBS" -gt 1 ]; then
+    if ! TEMP_SCHED_DIR="$(mktemp -d "${TMPDIR:-/tmp}/pgf-regression-XXXXXX")"; then
+        clog ERROR "cannot create a temporary scheduling directory"
+        exit 2
+    fi
+    SCHED_DIR="$TEMP_SCHED_DIR"
+    trap 'rm -rf "$TEMP_SCHED_DIR"' EXIT
+fi
+[ -n "$SCHED_DIR" ] && CASES_ROOT="$SCHED_DIR/cases"
+
+T_SUITE_START=$(date +%s)
+
+if [ "$STATE_ACTIVE" = true ]; then
+    REG_EVENT_STREAMS=("$SUITE_EVENTS")
+    reg_state header --stream "$SUITE_EVENTS" \
+        --field "suite=$SUITE_ID" --field "driver=$DRIVER" \
+        --field "project_root=$REPO_ROOT"
+    suite_args=(listing --record snapshot --out "$SCHED_DIR/suite.json"
+                --suite "$SUITE_ID" --driver "$DRIVER"
+                --project-root "$REPO_ROOT" --runner "$(basename "$RUN_CASE")"
+                --field "tag=$TAG" --int "jobs=$JOBS" --bool "no_run=$SKIP_RUN"
+                --field "rtol=$RTOL" --field "atol=$ATOL"
+                --field "state_dir=$SCHED_DIR" --field "status=running"
+                --num "started_epoch=$T_SUITE_START")
+    [ -n "$ONLY_CASE" ] && suite_args+=(--field "case_filter=$ONLY_CASE")
+    listing_args suite_args
+    reg_state "${suite_args[@]}"
+    reg_event suite_started \
+        --field "suite_id=$SUITE_ID" --field "driver=$DRIVER" \
+        --int "n_cases=${#SEL_IDS[@]}" --int "jobs=$JOBS" \
+        --field "tag=$TAG" --bool "no_run=$SKIP_RUN"
+fi
+
 # Print run header.
 clog INFO "=================================================="
 clog INFO "  PGF regression suite"
 clog INFO "  tag:     $TAG"
 clog INFO "  rtol:    $RTOL   atol: $ATOL"
-[ "$SKIP_RUN" = true ] && clog INFO "  mode:    compare only (--no-run)"
-[ -n "$ONLY_CASE" ]    && clog INFO "  filter:  $ONLY_CASE"
+[ "$SKIP_RUN" = true ]  && clog INFO "  mode:    compare only (--no-run)"
+[ -n "$ONLY_CASE" ]     && clog INFO "  filter:  $ONLY_CASE"
+[ "$JOBS" -gt 1 ]       && clog INFO "  jobs:    $JOBS cases at a time"
+[ "$STATE_ACTIVE" = true ] && clog INFO "  state:   $SCHED_DIR"
 clog INFO "=================================================="
 
-# Outcomes accumulate in the library (reg_record/reg_summary).
-for line in "${CASE_LINES[@]}"; do
-    caseRel=$(awk '{print $1}' <<< "$line")
-    caseTag=$(awk '{print $2}' <<< "$line")
-    [ -z "$caseTag" ] && caseTag="fast"
+for i in "${!SEL_IDS[@]}"; do
+    reg_event case_queued --field "case_id=${SEL_IDS[$i]}" --field "tag=${SEL_TAGS[$i]}"
+done
 
-    # Tag filter (skip unless --tag all or tag matches).
-    if [ "$TAG" != "all" ] && [ "$caseTag" != "$TAG" ]; then
-        continue
+# -- per-case execution -------------------------------------------------------
+
+# precheck <case-id> — validate what the driver can validate before handing the
+#   case to the runner. Echoes a summary-name suffix and returns 2 on failure.
+#   Its diagnostics name the offending path, so they stand on their own whether
+#   or not a per-case header was printed first. (The runner re-checks both
+#   conditions; keeping them here preserves the suite's own diagnostics and
+#   avoids launching a run that cannot work.)
+precheck() {
+    local id="$1" dir="$REPO_ROOT/$1"
+    if [ ! -d "$dir" ]; then
+        clog ERROR "  directory missing: $dir"
+        echo " (missing dir)"
+        return 2
     fi
-
-    # --case filter.
-    if [ -n "$ONLY_CASE" ] && \
-       [ "$(basename "$caseRel")" != "$ONLY_CASE" ] && \
-       [ "$caseRel" != "$ONLY_CASE" ]; then
-        continue
-    fi
-
-    caseDir="$REPO_ROOT/$caseRel"
-    caseName="$(basename "$caseRel")"
-
-    clog INFO "--------------------------------------------------"
-    clog INFO "  case: $caseName  [tag: $caseTag]"
-
-    if [ ! -d "$caseDir" ]; then
-        clog ERROR "  directory missing: $caseDir"
-        reg_record "$caseName (missing dir)" 2 "-"
-        continue
-    fi
-
     # A missing baseline is an ERROR, not a silent skip: a case with no
     # reference/ cannot be compared, so it must not pass unnoticed. (Capture a
     # baseline locally; see README § Regression Testing.)
-    if [ ! -d "$caseDir/reference/postProcessing" ]; then
-        clog ERROR "  no reference baseline: $caseDir/reference/postProcessing"
-        reg_record "$caseName (no baseline)" 2 "-"
-        continue
+    if [ ! -d "$dir/reference/postProcessing" ]; then
+        clog ERROR "  no reference baseline: $dir/reference/postProcessing"
+        echo " (no baseline)"
+        return 2
+    fi
+    echo ""
+    return 0
+}
+
+# run_one <index> — run one case's runner and return its exit status verbatim.
+#   With a scheduling directory the runner's streams are captured per case (so
+#   concurrent cases cannot interleave, and an observer gets the logs); without
+#   one they go straight to the terminal.
+run_one() {
+    local idx="$1"
+    local id="${SEL_IDS[$idx]}"
+    local args=("$REPO_ROOT/$id")
+    [ "$SKIP_RUN" = true ] && args+=(--no-run)
+    args+=(--rtol "$RTOL" --atol "$ATOL" --compare "$COMPARE"
+           --case-id "$id" --suite-id "$SUITE_ID")
+
+    if [ -z "$CASES_ROOT" ]; then
+        "$RUN_CASE" "${args[@]}"
+        return $?
     fi
 
-    runFlag=""
-    [ "$SKIP_RUN" = true ] && runFlag="--no-run"
+    local cs="$CASES_ROOT/$id"
+    mkdir -p "$cs"
+    # Drop any result from an earlier run in this directory: a stale result.json
+    # must never be able to stand in for a case that died before writing one.
+    rm -f "$cs/result.json"
+    args+=(--state-dir "$cs")
+    [ "$STATE_ACTIVE" = true ] && args+=(--suite-events "$SUITE_EVENTS")
+    "$RUN_CASE" "${args[@]}" >"$cs/stdout.log" 2>"$cs/stderr.log"
+    return $?
+}
 
-    t_start=$(date +%s)
-    "$RUN_CASE" "$caseDir" $runFlag --rtol "$RTOL" --atol "$ATOL" --compare "$COMPARE"
-    rc=$?
-    t_elapsed=$(( $(date +%s) - t_start ))
-    reg_record "$caseName" "$rc" "${t_elapsed}s"
+# replay_case_output <case-id> — echo a captured case's streams through.
+replay_case_output() {
+    local cs="$CASES_ROOT/$1"
+    [ -s "$cs/stdout.log" ] && cat "$cs/stdout.log"
+    [ -s "$cs/stderr.log" ] && cat "$cs/stderr.log" >&2
+    return 0
+}
+
+# RES_RCS[index] — the exit status the driver actually waited on for each case,
+#   kept alongside the library's own summary accumulator because the final suite
+#   result JSON has to report the observed status even for a case whose runner
+#   never wrote one.
+RES_RCS=()
+
+# record_case <index> <rc> <time-string> [name-suffix] — accumulate one outcome.
+record_case() {
+    RES_RCS[$1]="$2"
+    reg_record "$(basename "${SEL_IDS[$1]}")${4:-}" "$2" "$3"
+}
+
+# record_outcome <index> <rc> <seconds> — accumulate and print the verdict line.
+record_outcome() {
+    local idx="$1" rc="$2" secs="$3"
+    record_case "$idx" "$rc" "${secs}s"
     if [ "$rc" -eq 0 ]; then
-        clog SUCCESS "  $(reg_classify "$rc")  (${t_elapsed}s)"
+        clog SUCCESS "  $(reg_classify "$rc")  (${secs}s)"
     else
-        clog ERROR "  $(reg_classify "$rc")  (${t_elapsed}s)"
+        clog ERROR "  $(reg_classify "$rc")  (${secs}s)"
     fi
-done
+}
+
+# record_precheck_failure <index> <name-suffix> — a case the driver refused to
+#   launch. Recorded as ERROR with no elapsed time, since none was spent.
+record_precheck_failure() {
+    record_case "$1" 2 "-" "$2"
+    reg_event case_finished \
+        --field "case_id=${SEL_IDS[$1]}" --int exit_code=2 \
+        --field "status=ERROR" --field "phase=queued" \
+        --field "message=driver pre-check failed:${2}"
+}
+
+# -- sequential scheduling (the default) --------------------------------------
+
+run_sequential() {
+    local idx id suffix rc t_start t_elapsed
+    for idx in "${!SEL_IDS[@]}"; do
+        id="${SEL_IDS[$idx]}"
+
+        clog INFO "--------------------------------------------------"
+        clog INFO "  case: $(basename "$id")  [tag: ${SEL_TAGS[$idx]}]"
+
+        if ! suffix="$(precheck "$id")"; then
+            record_precheck_failure "$idx" "$suffix"
+            continue
+        fi
+
+        t_start=$(date +%s)
+        run_one "$idx"
+        rc=$?
+        t_elapsed=$(( $(date +%s) - t_start ))
+        [ -n "$CASES_ROOT" ] && replay_case_output "$id"
+        record_outcome "$idx" "$rc" "$t_elapsed"
+    done
+}
+
+# -- bounded concurrent scheduling (--jobs N) ---------------------------------
+#
+# The pool mechanics (atomic claim, status capture, waiting for every worker) are
+# reg_run_pool in tools/regressionLib.sh, shared with the DEM driver. What stays
+# here is this suite's own business: which cases are runnable, and how a
+# collected status becomes a summary row.
+
+run_concurrent() {
+    local runnable=() idx suffix rc secs cs
+
+    # Pre-checks run in the parent so their diagnostics stay in one place and a
+    # case that cannot run is never handed to a worker.
+    for idx in "${!SEL_IDS[@]}"; do
+        if ! suffix="$(precheck "${SEL_IDS[$idx]}")"; then
+            record_precheck_failure "$idx" "$suffix"
+            continue
+        fi
+        mkdir -p "$CASES_ROOT/${SEL_IDS[$idx]}"
+        runnable+=("$idx")
+    done
+
+    [ "${#runnable[@]}" -eq 0 ] && return 0
+
+    clog INFO "  running ${#runnable[@]} case(s), $JOBS at a time"
+    clog INFO "--------------------------------------------------"
+
+    reg_run_pool "$JOBS" "$CASES_ROOT" SEL_IDS runnable run_one
+
+    # Collect in cases.list order: the summary is deterministic even though the
+    # cases finished in whatever order they finished.
+    for idx in "${runnable[@]}"; do
+        cs="$CASES_ROOT/${SEL_IDS[$idx]}"
+        rc="$(reg_pool_status "$cs")"
+        secs="$(reg_pool_seconds "$cs")"
+        [ -f "$cs/rc" ] || clog ERROR \
+            "  ${SEL_IDS[$idx]}: runner exited without recording a status"
+        record_case "$idx" "$rc" "${secs}s"
+    done
+
+    # A failing case's captured output is replayed here, after the wait and in
+    # cases.list order — interleaving it live across workers would make it
+    # unreadable and non-deterministic.
+    for idx in "${runnable[@]}"; do
+        [ "${RES_RCS[$idx]}" -eq 0 ] && continue
+        clog ERROR "--------------------------------------------------"
+        clog ERROR "  ${SEL_IDS[$idx]} — captured output"
+        replay_case_output "${SEL_IDS[$idx]}"
+    done
+}
+
+if [ "$JOBS" -eq 1 ]; then
+    run_sequential
+else
+    run_concurrent
+fi
 
 reg_summary "regression summary"
-exit $?
+suite_rc=$?
+
+if [ "$STATE_ACTIVE" = true ]; then
+    T_SUITE_END=$(date +%s)
+    result_args=(suite-result --path "$SCHED_DIR/result.json"
+                 --exit-code "$suite_rc" --suite "$SUITE_ID" --driver "$DRIVER"
+                 --cases-root "$CASES_ROOT"
+                 --num "started_epoch=$T_SUITE_START"
+                 --started-epoch "$T_SUITE_START" --ended-epoch "$T_SUITE_END"
+                 --int "jobs=$JOBS" --field "tag=$TAG" --bool "no_run=$SKIP_RUN"
+                 --field "rtol=$RTOL" --field "atol=$ATOL")
+    for i in "${!SEL_IDS[@]}"; do
+        result_args+=(--case-id "${SEL_IDS[$i]}"
+                      --case-exit-code "${RES_RCS[$i]:-2}")
+    done
+    reg_state "${result_args[@]}"
+    reg_event suite_finished --int "exit_code=$suite_rc" \
+        --field "status=$( [ "$suite_rc" -eq 0 ] && echo PASS || echo FAIL )" \
+        --int "n_cases=${#SEL_IDS[@]}"
+fi
+
+exit "$suite_rc"

--- a/applications/test/regression/Allrun.yade
+++ b/applications/test/regression/Allrun.yade
@@ -3,10 +3,18 @@
 # Runs each case in cases_yade.list; test-mode controls and validation are in
 # tools/runDEMCase.sh (not in the tutorial Allrun scripts).
 #
+# Like the serial driver, this script is the authority on its own suite: the DEM
+# inventory, the step/wall-clock caps, the coupling and output assertions, and
+# whether the suite is green. It shares only the outcome taxonomy, the run-state
+# protocol and the scheduling mechanics with the serial driver — never its
+# cleanup contract or its assertions, which are different on purpose.
+#
 # Requirements: solver built with ./build.sh --yade, Yade + mpirun installed.
 #
 # Usage:
-#   applications/test/regression/Allrun.yade [--case <name>]
+#   applications/test/regression/Allrun.yade [--case <name>] [--short]
+#                                           [--jobs N] [--list] [--json]
+#                                           [--state-dir DIR]
 
 set -u
 
@@ -14,22 +22,40 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 # Shared runner logic (case loading, outcome classification, summary + honest
-# exit); the library sources helpers.sh internally.
+# exit, run-state serialisation, scheduling mechanics); the library sources
+# helpers.sh internally.
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/tools/regressionLib.sh"
 
 CASES_FILE="$SCRIPT_DIR/cases_yade.list"
+RUN_CASE="$SCRIPT_DIR/tools/runDEMCase.sh"
+SUITE_ID="yade"
+DRIVER="Allrun.yade"
+
 ONLY_CASE=""
 SHORT_RUN=0
+JOBS=1
+LIST_ONLY=false
+AS_JSON=false
+STATE_DIR=""
 
 usage() {
     cat <<EOF
-Usage: $0 [--case <name>] [--short]
+Usage: $0 [options]
 
   --case <name>   Run only the named case (basename or repo-relative path).
   --short         Fast smoke test: set YADE_NSTEPS=200 so each case runs in
                   seconds instead of hours. Checks coupling handshake and VTK
                   output without running a full simulation.
+  --jobs <n>      Number of DEM CASES to run concurrently (default 1). This is
+                  suite concurrency only: it never changes a case's own MPI
+                  layout. Concurrent DEM execution is NOT verified — each case
+                  spawns its own mpirun/Yade tree, so raise this only
+                  deliberately, on a machine with the cores to spare.
+  --list          List the selected cases and exit without touching them.
+  --json          With --list, emit the machine-readable case manifest.
+  --state-dir <d> Write structured run state (suite.json, events.ndjson,
+                  result.json, cases/<id>/…) into <d> for an external observer.
   -h, --help      Show this help.
 EOF
 }
@@ -38,14 +64,84 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --case)  ONLY_CASE="$2"; shift 2 ;;
         --short) SHORT_RUN=1; shift ;;
+        --jobs|-j) JOBS="$2"; shift 2 ;;
+        --list) LIST_ONLY=true; shift ;;
+        --json) AS_JSON=true; shift ;;
+        --state-dir) STATE_DIR="$2"; shift 2 ;;
         -h|--help) usage; exit 0 ;;
         *) clog ERROR "Unknown option: $1"; usage; exit 2 ;;
     esac
 done
 
+if ! [[ "$JOBS" =~ ^[0-9]+$ ]] || [ "$JOBS" -lt 1 ]; then
+    clog ERROR "--jobs must be a positive integer (got: $JOBS)"
+    exit 2
+fi
+
+# An empty or unreadable DEM inventory is an ERROR, never green: a suite that
+# ran nothing must not report success (README § Regression Testing, outcome
+# contract). Skip the DEM suite by not invoking this driver, not by emptying it.
 if ! reg_load_cases "$CASES_FILE" CASE_LINES; then
-    clog WARNING "No cases listed in $CASES_FILE"
+    clog ERROR "empty or unreadable DEM suite: $CASES_FILE (nothing to run)"
+    exit 2
+fi
+
+# -- selection ----------------------------------------------------------------
+#
+# cases_yade.list is a bare inventory: one repo-relative case path per line, no
+# tag column. One implementation of the --case filter, used by both --list and
+# the run paths, so a listing cannot disagree with a run of the same arguments.
+
+SEL_IDS=()
+
+select_cases() {
+    local caseRel
+    for caseRel in "${CASE_LINES[@]}"; do
+        if [ -n "$ONLY_CASE" ] && \
+           [ "$(basename "$caseRel")" != "$ONLY_CASE" ] && \
+           [ "$caseRel" != "$ONLY_CASE" ]; then
+            continue
+        fi
+        SEL_IDS+=("$caseRel")
+    done
+}
+
+select_cases
+
+if [ "${#SEL_IDS[@]}" -eq 0 ]; then
+    clog ERROR "no case in $CASES_FILE matches case '$ONLY_CASE' (nothing to run)"
+    exit 2
+fi
+
+listing_args() {
+    local -n _out="$1"
+    local id
+    for id in "${SEL_IDS[@]}"; do
+        _out+=(--case-id "$id")
+    done
+}
+
+# -- listing mode -------------------------------------------------------------
+
+if [ "$LIST_ONLY" = true ]; then
+    if [ "$AS_JSON" = true ]; then
+        args=(listing --suite "$SUITE_ID" --driver "$DRIVER"
+              --project-root "$REPO_ROOT" --runner "$(basename "$RUN_CASE")"
+              --int "jobs=$JOBS" --bool "short=$SHORT_RUN")
+        [ -n "$ONLY_CASE" ] && args+=(--field "case_filter=$ONLY_CASE")
+        listing_args args
+        exec python3 "$REG_STATE_PY" "${args[@]}"
+    fi
+    clog INFO "suite $SUITE_ID — ${#SEL_IDS[@]} case(s) selected"
+    for id in "${SEL_IDS[@]}"; do
+        printf '  %s\n' "$id"
+    done
     exit 0
+fi
+
+if [ "$AS_JSON" = true ]; then
+    clog ERROR "--json is only meaningful with --list; run state goes to --state-dir"
+    exit 2
 fi
 
 # --short caps the step count and wall-clock, but a value the caller pre-set in
@@ -53,41 +149,222 @@ fi
 [ "$SHORT_RUN" -eq 1 ] && export YADE_NSTEPS="${YADE_NSTEPS:-200}"
 [ "$SHORT_RUN" -eq 1 ] && export YADE_TIMEOUT="${YADE_TIMEOUT:-300}"
 
+# -- run-state / output-capture setup ----------------------------------------
+
+SCHED_DIR=""
+CASES_ROOT=""
+SUITE_EVENTS=""
+STATE_ACTIVE=false
+TEMP_SCHED_DIR=""
+
+if [ -n "$STATE_DIR" ]; then
+    if ! mkdir -p "$STATE_DIR"; then
+        clog ERROR "cannot create state directory: $STATE_DIR"
+        exit 2
+    fi
+    SCHED_DIR="$(cd "$STATE_DIR" && pwd)"
+    STATE_ACTIVE=true
+    SUITE_EVENTS="$SCHED_DIR/events.ndjson"
+elif [ "$JOBS" -gt 1 ]; then
+    if ! TEMP_SCHED_DIR="$(mktemp -d "${TMPDIR:-/tmp}/pgf-yade-regression-XXXXXX")"; then
+        clog ERROR "cannot create a temporary scheduling directory"
+        exit 2
+    fi
+    SCHED_DIR="$TEMP_SCHED_DIR"
+    trap 'rm -rf "$TEMP_SCHED_DIR"' EXIT
+fi
+[ -n "$SCHED_DIR" ] && CASES_ROOT="$SCHED_DIR/cases"
+
+T_SUITE_START=$(date +%s)
+
+if [ "$STATE_ACTIVE" = true ]; then
+    REG_EVENT_STREAMS=("$SUITE_EVENTS")
+    reg_state header --stream "$SUITE_EVENTS" \
+        --field "suite=$SUITE_ID" --field "driver=$DRIVER" \
+        --field "project_root=$REPO_ROOT"
+    suite_args=(listing --record snapshot --out "$SCHED_DIR/suite.json"
+                --suite "$SUITE_ID" --driver "$DRIVER"
+                --project-root "$REPO_ROOT" --runner "$(basename "$RUN_CASE")"
+                --int "jobs=$JOBS" --bool "short=$SHORT_RUN"
+                --field "state_dir=$SCHED_DIR" --field "status=running"
+                --num "started_epoch=$T_SUITE_START")
+    [ -n "$ONLY_CASE" ] && suite_args+=(--field "case_filter=$ONLY_CASE")
+    listing_args suite_args
+    reg_state "${suite_args[@]}"
+    reg_event suite_started \
+        --field "suite_id=$SUITE_ID" --field "driver=$DRIVER" \
+        --int "n_cases=${#SEL_IDS[@]}" --int "jobs=$JOBS" \
+        --bool "short=$SHORT_RUN"
+fi
+
 clog INFO "=================================================="
 clog INFO "  PGF Yade regression suite"
-[ -n "$ONLY_CASE" ] && clog INFO "  filter: $ONLY_CASE"
-[ "$SHORT_RUN" -eq 1 ] && clog INFO "  mode: --short (YADE_NSTEPS=200)"
+[ -n "$ONLY_CASE" ]        && clog INFO "  filter: $ONLY_CASE"
+[ "$SHORT_RUN" -eq 1 ]     && clog INFO "  mode: --short (YADE_NSTEPS=$YADE_NSTEPS)"
+[ "$STATE_ACTIVE" = true ] && clog INFO "  state:   $SCHED_DIR"
+if [ "$JOBS" -gt 1 ]; then
+    clog INFO "  jobs:   $JOBS cases at a time"
+    clog WARNING "  concurrent DEM execution is unverified — each case spawns its"
+    clog WARNING "  own mpirun/Yade tree, so oversubscription is on you"
+fi
 clog INFO "=================================================="
 
-for caseRel in "${CASE_LINES[@]}"; do
-    caseName="$(basename "$caseRel")"
-
-    if [ -n "$ONLY_CASE" ] && [ "$caseName" != "$ONLY_CASE" ] && [ "$caseRel" != "$ONLY_CASE" ]; then
-        continue
-    fi
-
-    caseDir="$REPO_ROOT/$caseRel"
-
-    clog INFO "--------------------------------------------------"
-    clog INFO "  case: $caseName"
-
-    if [ ! -d "$caseDir" ]; then
-        clog ERROR "  directory missing: $caseDir"
-        reg_record "$caseName (missing dir)" 2 "-"
-        continue
-    fi
-
-    t_start=$(date +%s)
-    "$SCRIPT_DIR/tools/runDEMCase.sh" "$caseDir"
-    rc=$?
-    t_elapsed=$(( $(date +%s) - t_start ))
-    reg_record "$caseName" "$rc" "${t_elapsed}s"
-    if [ "$rc" -eq 0 ]; then
-        clog SUCCESS "  $(reg_classify "$rc")  (${t_elapsed}s)"
-    else
-        clog ERROR "  $(reg_classify "$rc")  (${t_elapsed}s)"
-    fi
+for id in "${SEL_IDS[@]}"; do
+    reg_event case_queued --field "case_id=$id"
 done
 
+# -- per-case execution -------------------------------------------------------
+
+# precheck <case-id> — what the driver can check before launching a DEM case.
+#   Echoes a summary-name suffix and returns 2 on failure. The coupling, VTK and
+#   dtInfo assertions belong to runDEMCase.sh and stay there.
+precheck() {
+    local dir="$REPO_ROOT/$1"
+    if [ ! -d "$dir" ]; then
+        clog ERROR "  directory missing: $dir"
+        echo " (missing dir)"
+        return 2
+    fi
+    echo ""
+    return 0
+}
+
+# run_one <index> — run one DEM case's runner and return its status verbatim.
+run_one() {
+    local idx="$1"
+    local id="${SEL_IDS[$idx]}"
+    local args=("$REPO_ROOT/$id" --case-id "$id" --suite-id "$SUITE_ID")
+
+    if [ -z "$CASES_ROOT" ]; then
+        "$RUN_CASE" "${args[@]}"
+        return $?
+    fi
+
+    local cs="$CASES_ROOT/$id"
+    mkdir -p "$cs"
+    # A stale result must never be able to stand in for a case that died before
+    # writing one.
+    rm -f "$cs/result.json"
+    args+=(--state-dir "$cs")
+    [ "$STATE_ACTIVE" = true ] && args+=(--suite-events "$SUITE_EVENTS")
+    "$RUN_CASE" "${args[@]}" >"$cs/stdout.log" 2>"$cs/stderr.log"
+    return $?
+}
+
+replay_case_output() {
+    local cs="$CASES_ROOT/$1"
+    [ -s "$cs/stdout.log" ] && cat "$cs/stdout.log"
+    [ -s "$cs/stderr.log" ] && cat "$cs/stderr.log" >&2
+    return 0
+}
+
+RES_RCS=()
+
+record_case() {
+    RES_RCS[$1]="$2"
+    reg_record "$(basename "${SEL_IDS[$1]}")${4:-}" "$2" "$3"
+}
+
+record_outcome() {
+    local idx="$1" rc="$2" secs="$3"
+    record_case "$idx" "$rc" "${secs}s"
+    if [ "$rc" -eq 0 ]; then
+        clog SUCCESS "  $(reg_classify "$rc")  (${secs}s)"
+    else
+        clog ERROR "  $(reg_classify "$rc")  (${secs}s)"
+    fi
+}
+
+record_precheck_failure() {
+    record_case "$1" 2 "-" "$2"
+    reg_event case_finished \
+        --field "case_id=${SEL_IDS[$1]}" --int exit_code=2 \
+        --field "status=ERROR" --field "phase=queued" \
+        --field "message=driver pre-check failed:${2}"
+}
+
+run_sequential() {
+    local idx id suffix rc t_start t_elapsed
+    for idx in "${!SEL_IDS[@]}"; do
+        id="${SEL_IDS[$idx]}"
+
+        clog INFO "--------------------------------------------------"
+        clog INFO "  case: $(basename "$id")"
+
+        if ! suffix="$(precheck "$id")"; then
+            record_precheck_failure "$idx" "$suffix"
+            continue
+        fi
+
+        t_start=$(date +%s)
+        run_one "$idx"
+        rc=$?
+        t_elapsed=$(( $(date +%s) - t_start ))
+        [ -n "$CASES_ROOT" ] && replay_case_output "$id"
+        record_outcome "$idx" "$rc" "$t_elapsed"
+    done
+}
+
+run_concurrent() {
+    local runnable=() idx suffix rc secs cs
+
+    for idx in "${!SEL_IDS[@]}"; do
+        if ! suffix="$(precheck "${SEL_IDS[$idx]}")"; then
+            record_precheck_failure "$idx" "$suffix"
+            continue
+        fi
+        mkdir -p "$CASES_ROOT/${SEL_IDS[$idx]}"
+        runnable+=("$idx")
+    done
+
+    [ "${#runnable[@]}" -eq 0 ] && return 0
+
+    clog INFO "  running ${#runnable[@]} case(s), $JOBS at a time"
+    clog INFO "--------------------------------------------------"
+
+    reg_run_pool "$JOBS" "$CASES_ROOT" SEL_IDS runnable run_one
+
+    for idx in "${runnable[@]}"; do
+        cs="$CASES_ROOT/${SEL_IDS[$idx]}"
+        rc="$(reg_pool_status "$cs")"
+        secs="$(reg_pool_seconds "$cs")"
+        [ -f "$cs/rc" ] || clog ERROR \
+            "  ${SEL_IDS[$idx]}: runner exited without recording a status"
+        record_case "$idx" "$rc" "${secs}s"
+    done
+
+    for idx in "${runnable[@]}"; do
+        [ "${RES_RCS[$idx]}" -eq 0 ] && continue
+        clog ERROR "--------------------------------------------------"
+        clog ERROR "  ${SEL_IDS[$idx]} — captured output"
+        replay_case_output "${SEL_IDS[$idx]}"
+    done
+}
+
+if [ "$JOBS" -eq 1 ]; then
+    run_sequential
+else
+    run_concurrent
+fi
+
 reg_summary "Yade regression summary"
-exit $?
+suite_rc=$?
+
+if [ "$STATE_ACTIVE" = true ]; then
+    T_SUITE_END=$(date +%s)
+    result_args=(suite-result --path "$SCHED_DIR/result.json"
+                 --exit-code "$suite_rc" --suite "$SUITE_ID" --driver "$DRIVER"
+                 --cases-root "$CASES_ROOT"
+                 --started-epoch "$T_SUITE_START" --ended-epoch "$T_SUITE_END"
+                 --int "jobs=$JOBS" --bool "short=$SHORT_RUN")
+    for i in "${!SEL_IDS[@]}"; do
+        result_args+=(--case-id "${SEL_IDS[$i]}"
+                      --case-exit-code "${RES_RCS[$i]:-2}")
+    done
+    reg_state "${result_args[@]}"
+    reg_event suite_finished --int "exit_code=$suite_rc" \
+        --field "status=$( [ "$suite_rc" -eq 0 ] && echo PASS || echo FAIL )" \
+        --int "n_cases=${#SEL_IDS[@]}"
+fi
+
+exit "$suite_rc"

--- a/applications/test/regression/tools/regressionLib.sh
+++ b/applications/test/regression/tools/regressionLib.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 # regressionLib.sh — shared logic for the PGF regression runners.
 #
-# Source-only library, sibling to runCase.sh / runDEMCase.sh. It sources
-# helpers.sh (for clog) so each driver (Allrun, Allrun.yade) sources only this
-# file. It holds the pieces that must NOT drift between the serial and DEM
-# runners: how a suite is loaded, how a child exit code becomes an outcome, and
-# how the summary decides whether the whole suite is green.
+# Source-only library, sourced by both suite drivers (Allrun, Allrun.yade) and
+# both per-case runners (runCase.sh, runDEMCase.sh). It sources helpers.sh (for
+# clog) so a caller sources only this file. It holds the pieces that must NOT
+# drift between the serial and DEM runners: how a suite is loaded, how a child
+# exit code becomes an outcome, how the summary decides whether the whole suite
+# is green, and how run state is serialised for an external observer.
+#
+# What it deliberately does NOT hold: the serial and DEM runners' own argument
+# parsing, cleanup contracts and output assertions. Those differ, and collapsing
+# them into one mode-switching script would hide exactly the details a
+# regression runner has to get right.
 #
 # Outcome taxonomy (child exit code -> label -> green?), standard shell
 # conventions:
@@ -25,7 +31,8 @@
 # Source-only: refuse direct execution.
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     echo "regressionLib.sh is a source-only library — do not execute it directly." >&2
-    echo "It is sourced by applications/test/regression/{Allrun,Allrun.yade}." >&2
+    echo "It is sourced by applications/test/regression/{Allrun,Allrun.yade} and" >&2
+    echo "by tools/{runCase.sh,runDEMCase.sh}." >&2
     exit 1
 fi
 
@@ -61,14 +68,137 @@ reg_load_cases() {
 }
 
 # reg_signal_name <n> — conventional name for a signal number (one table).
+# Kept in step with regressionState.py's signal_name() so the printed summary
+# and the JSON result never disagree about what killed a case.
 reg_signal_name() {
     case "$1" in
+        1)  echo "SIGHUP"  ;;
+        2)  echo "SIGINT"  ;;
+        3)  echo "SIGQUIT" ;;
+        4)  echo "SIGILL"  ;;
         6)  echo "SIGABRT" ;;
+        8)  echo "SIGFPE"  ;;
         9)  echo "SIGKILL" ;;
         11) echo "SIGSEGV" ;;
+        13) echo "SIGPIPE" ;;
+        14) echo "SIGALRM" ;;
         15) echo "SIGTERM" ;;
         *)  echo "SIG$1"   ;;
     esac
+}
+
+# -- Structured run-state protocol (optional) ---------------------------------
+#
+# The runners' exit codes remain the contract for shell callers; the JSON below
+# is an additional representation for an external observer (CI, a TUI). It is
+# entirely opt-in: with no state directory configured, every helper here is a
+# no-op and the drivers behave exactly as they did before.
+#
+# Serialisation lives in tools/regressionState.py (standard library only, no
+# project imports). These wrappers exist so a caller never has to build helper
+# argv by hand, and so a *reporting* failure can never be mistaken for a case
+# outcome — see reg_state below.
+
+REG_STATE_PY="$_REGLIB_DIR/regressionState.py"
+
+# Streams that reg_event appends to. A caller sets this to the event files it
+# wants (case stream, suite stream, or both); empty disables event emission.
+REG_EVENT_STREAMS=()
+
+# reg_state <subcommand> [args...] — call the state helper.
+#   Always returns 0. A state write that fails is a reporting problem, so it
+#   warns and carries on: turning it into a non-zero status here would corrupt
+#   the outcome of the case being reported on.
+reg_state() {
+    [ -f "$REG_STATE_PY" ] || return 0
+    if ! python3 "$REG_STATE_PY" "$@"; then
+        echo "[regression] warning: run-state write failed ($1)" >&2
+    fi
+    return 0
+}
+
+# reg_event <type> [extra helper args...] — append one event to every stream in
+#   REG_EVENT_STREAMS. A no-op when no stream is configured.
+reg_event() {
+    [ "${#REG_EVENT_STREAMS[@]}" -gt 0 ] || return 0
+    local _type="$1"; shift
+    local _args=() _stream
+    for _stream in "${REG_EVENT_STREAMS[@]}"; do
+        _args+=(--stream "$_stream")
+    done
+    reg_state event --type "$_type" "${_args[@]}" "$@"
+}
+
+# -- Bounded case scheduling --------------------------------------------------
+#
+# Shared because getting it wrong is how a suite silently runs a case twice or
+# loses a child's status — but deliberately *only* the mechanics. Which cases
+# exist, which are runnable, and what running one means stay with each driver.
+#
+# The pool is <jobs> worker subshells pulling from one list of case indices. A
+# worker claims a case with `mkdir <case-state>/.claim`, which either creates the
+# directory or fails, so exactly one worker can win each case on any POSIX
+# filesystem — no lock file, no lock daemon, no second scheduler to keep in step.
+# Each worker records its case's elapsed time and then its exit status; the
+# status file is written last, so its presence means the case really finished.
+# The caller reads those files back in its own order after every worker has been
+# waited for, which is what makes the summary deterministic even though cases
+# finish in whatever order they finish.
+#
+# Workers stay in the caller's process group, so an interactive Ctrl-C reaches
+# every case and its children exactly as it does for a sequential run. Nothing
+# here signals by process name, and nothing here terminates anything: a case's
+# own runner owns any timeout it needs, and scopes it to its own process group.
+
+# reg_run_pool <jobs> <cases-root> <ids-var> <indices-var> <run-fn>
+#   <ids-var>     name of an array of case ids, indexed as the driver indexes them
+#   <indices-var> name of an array of indices into <ids-var> to run
+#   <run-fn>      driver function taking one index and returning the case status
+reg_run_pool() {
+    local _jobs="$1" _root="$2"
+    local -n _ids="$3"
+    local -n _todo="$4"
+    local _runfn="$5"
+    local _slot _pids=() _pid
+
+    for _slot in $(seq 1 "$_jobs"); do
+        (
+            for w_idx in "${_todo[@]}"; do
+                w_cs="$_root/${_ids[$w_idx]}"
+                mkdir "$w_cs/.claim" 2>/dev/null || continue
+                w_t0=$(date +%s)
+                "$_runfn" "$w_idx"
+                w_rc=$?
+                w_secs=$(( $(date +%s) - w_t0 ))
+                printf '%s\n' "$w_secs" > "$w_cs/secs"
+                printf '%s\n' "$w_rc"   > "$w_cs/rc"
+                # One short line per completion: a single write, so concurrent
+                # workers cannot tear each other's progress output.
+                printf '  %-7s %5s   %s\n' \
+                    "$(reg_classify "$w_rc")" "${w_secs}s" "${_ids[$w_idx]}"
+            done
+        ) &
+        _pids+=("$!")
+    done
+
+    # Wait for every launched worker before the caller reads any status back, so
+    # no case can still be writing its result when the summary is assembled.
+    for _pid in "${_pids[@]}"; do
+        wait "$_pid" || true
+    done
+}
+
+# reg_pool_status <case-state-dir> — echo the exit status a worker recorded.
+#   Echoes 2 when there is none: a worker that died without recording a status
+#   is an infrastructure ERROR, and an absent status is never read as a pass.
+reg_pool_status() {
+    if [ -f "$1/rc" ]; then cat "$1/rc"; else echo 2; fi
+}
+
+# reg_pool_seconds <case-state-dir> — echo the elapsed seconds a worker recorded,
+#   or "?" when the worker never got that far.
+reg_pool_seconds() {
+    if [ -f "$1/secs" ]; then cat "$1/secs"; else echo "?"; fi
 }
 
 # reg_classify <rc> — echo the outcome label for a child exit code, per the

--- a/applications/test/regression/tools/regressionState.py
+++ b/applications/test/regression/tools/regressionState.py
@@ -1,0 +1,611 @@
+#!/usr/bin/env python3
+"""Structured run-state emitter for the PGF regression runners.
+
+The regression drivers (`Allrun`, `Allrun.yade`) and the per-case runners
+(`runCase.sh`, `runDEMCase.sh`) are the authority on what a case did. This
+helper is the *serialisation* side of that authority: it turns shell-side facts
+into JSON that an external observer (a CI job, a TUI, `foamcli test`) can read
+while the suite runs, without any consumer having to parse human log output.
+
+It is deliberately a leaf: standard library only, no project imports, no
+knowledge of any consumer. The exit-code contract in `regressionLib.sh` stays
+authoritative for shell callers — this JSON is an *additional* representation,
+never a replacement.
+
+State directory layout (paths are supplied by the caller, never invented here):
+
+    <state-dir>/
+      suite.json            suite-level snapshot (selection, options, progress)
+      events.ndjson         append-only suite event stream
+      result.json           final suite result
+      cases/<case-id>/
+        state.json          current per-case snapshot (phase, timing)
+        events.ndjson       append-only per-case event stream
+        result.json         terminal per-case result
+        stdout.log          captured runner stdout
+        stderr.log          captured runner stderr
+
+Every record carries `schema_version` and a `record` discriminator, so a
+consumer can tell a stream header from an event without positional assumptions:
+
+    {"schema_version":1,"record":"stream_header",...}   first line of a stream
+    {"schema_version":1,"record":"event","event":"case_started",...}
+    {"schema_version":1,"record":"snapshot",...}        suite.json / state.json
+    {"schema_version":1,"record":"result",...}          result.json
+
+Guarantees
+----------
+* Snapshots and results are written to a temporary file in the destination
+  directory and then `os.replace`d, so a reader never sees a partial JSON
+  document and a killed writer cannot leave a truncated one behind.
+* Event lines are emitted as a single `write(2)` to an `O_APPEND` descriptor.
+  On Linux that makes each line atomic with respect to other appenders as long
+  as it stays under `PIPE_BUF`, which is why long free-text values are
+  truncated (see `_MAX_VALUE_CHARS`) — concurrent case runners share the suite
+  stream.
+* Values are JSON-encoded, so quotes, newlines, tabs and non-ASCII bytes in
+  paths or error messages cannot break the one-object-per-line invariant.
+
+Usage (all subcommands are safe to call when the caller has no state dir — the
+shell wrappers simply do not call them):
+
+    regressionState.py header   --stream S [--field k=v ...]
+    regressionState.py event    --type NAME --stream S [--stream S2] [fields]
+    regressionState.py snapshot --path P [--record NAME] [fields]
+    regressionState.py result   --path P --exit-code N [--status S] [fields]
+    regressionState.py listing  --suite S --driver D --project-root R \
+                                --case-id ID --case-tag TAG ... [--out P]
+    regressionState.py suite-result --path P --exit-code N --cases-root R \
+                                --case-id ID --case-exit-code N ...
+
+Field-typing options, usable on every subcommand that takes fields:
+
+    --field k=v   string        --int k=v    integer
+    --num k=v     float         --bool k=v   true/false/1/0/yes/no
+    --json k=v    raw JSON (objects, arrays, null)
+    --artifact k=v  string, collected under an "artifacts" object
+
+Exit status: 0 on success, 1 on a write or usage failure. Callers must treat a
+failure here as a reporting problem, never as a case outcome — a state write
+that fails must not turn a PASS into a FAIL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import sys
+import tempfile
+from datetime import datetime
+
+SCHEMA_VERSION = 1
+
+_MAX_VALUE_CHARS = 1500
+"""Cap on a single string value, so one event line stays inside PIPE_BUF.
+
+Concurrent case runners append to the same suite stream; atomicity of an
+appended line only holds while the line is small. A comparator failure dump or
+a stack trace would otherwise blow past that, so long values are truncated with
+an explicit marker rather than silently risking an interleaved line.
+"""
+
+# Statuses, keyed off the child exit code exactly as tools/regressionLib.sh
+# classifies them. Kept in one place here so the JSON status can never drift
+# from the shell summary.
+PASS = "PASS"
+FAIL = "FAIL"
+ERROR = "ERROR"
+TIMEOUT = "TIMEOUT"
+CRASH = "CRASH"
+
+
+def classify(exit_code: int) -> str:
+    """Return the outcome label for a child exit code.
+
+    Mirrors `reg_classify` in `tools/regressionLib.sh`: 0 PASS, 1 FAIL,
+    2 ERROR, 124 TIMEOUT, >128 CRASH (signal death), anything else ERROR.
+    """
+    if exit_code == 0:
+        return PASS
+    if exit_code == 1:
+        return FAIL
+    if exit_code == 2:
+        return ERROR
+    if exit_code == 124:
+        return TIMEOUT
+    if exit_code > 128:
+        return CRASH
+    return ERROR
+
+
+def signal_name(number: int) -> str:
+    """Conventional name for a signal number (`6` -> `"SIGABRT"`)."""
+    try:
+        return signal.Signals(number).name
+    except (ValueError, AttributeError):
+        return f"SIG{number}"
+
+
+def _now_iso() -> str:
+    """Current local time as an ISO-8601 string with offset, ms resolution."""
+    return datetime.now().astimezone().isoformat(timespec="milliseconds")
+
+
+def _iso_from_epoch(epoch: float) -> str:
+    """Format a Unix epoch (as produced by `date +%s`) the same way."""
+    return datetime.fromtimestamp(epoch).astimezone().isoformat(
+        timespec="milliseconds"
+    )
+
+
+def _truncate(text: str) -> str:
+    """Clip an over-long string value, marking that it was clipped."""
+    if len(text) <= _MAX_VALUE_CHARS:
+        return text
+    return text[:_MAX_VALUE_CHARS] + f"…[truncated, {len(text)} chars]"
+
+
+# -- field collection --------------------------------------------------------
+
+
+def _split(pair: str, kind: str) -> tuple[str, str]:
+    """Split a `key=value` option argument, erroring out on a missing `=`."""
+    key, sep, value = pair.partition("=")
+    if not sep or not key:
+        raise SystemExit(f"regressionState.py: malformed --{kind} '{pair}' (want key=value)")
+    return key, value
+
+
+def _parse_bool(value: str) -> bool:
+    lowered = value.strip().lower()
+    if lowered in ("1", "true", "yes", "on"):
+        return True
+    if lowered in ("0", "false", "no", "off", ""):
+        return False
+    raise SystemExit(f"regressionState.py: not a boolean: '{value}'")
+
+
+def collect_fields(args: argparse.Namespace) -> dict:
+    """Build the caller-supplied field mapping from the typed field options.
+
+    Merge order is fixed (`--field`, `--int`, `--num`, `--bool`, `--json`) so
+    the emitted key order is deterministic regardless of command-line order.
+    """
+    fields: dict = {}
+    for pair in args.field or []:
+        key, value = _split(pair, "field")
+        fields[key] = _truncate(value)
+    for pair in args.int_ or []:
+        key, value = _split(pair, "int")
+        try:
+            fields[key] = int(value)
+        except ValueError:
+            raise SystemExit(f"regressionState.py: not an integer: '{value}'")
+    for pair in args.num or []:
+        key, value = _split(pair, "num")
+        try:
+            fields[key] = float(value)
+        except ValueError:
+            raise SystemExit(f"regressionState.py: not a number: '{value}'")
+    for pair in args.bool_ or []:
+        key, value = _split(pair, "bool")
+        fields[key] = _parse_bool(value)
+    for pair in args.json_ or []:
+        key, value = _split(pair, "json")
+        try:
+            fields[key] = json.loads(value)
+        except ValueError as exc:
+            raise SystemExit(f"regressionState.py: not valid JSON for '{key}': {exc}")
+    artifacts = {}
+    for pair in getattr(args, "artifact", None) or []:
+        key, value = _split(pair, "artifact")
+        artifacts[key] = _truncate(value)
+    if artifacts:
+        fields["artifacts"] = artifacts
+    return fields
+
+
+def add_field_options(parser: argparse.ArgumentParser) -> None:
+    """Attach the shared typed-field options to a subcommand parser."""
+    parser.add_argument("--field", action="append", metavar="K=V",
+                        help="string field (repeatable)")
+    parser.add_argument("--int", dest="int_", action="append", metavar="K=V",
+                        help="integer field (repeatable)")
+    parser.add_argument("--num", action="append", metavar="K=V",
+                        help="float field (repeatable)")
+    parser.add_argument("--bool", dest="bool_", action="append", metavar="K=V",
+                        help="boolean field (repeatable)")
+    parser.add_argument("--json", dest="json_", action="append", metavar="K=V",
+                        help="raw-JSON field (repeatable)")
+    parser.add_argument("--artifact", action="append", metavar="K=PATH",
+                        help="artifact path, collected under 'artifacts' (repeatable)")
+
+
+# -- writers -----------------------------------------------------------------
+
+
+def write_json_atomic(path: str, payload: dict) -> None:
+    """Write *payload* to *path* atomically (temp file in the same dir, rename).
+
+    A reader either sees the previous content or the complete new content —
+    never a half-written document — which is what makes `result.json` safe to
+    poll while the suite is still running.
+    """
+    directory = os.path.dirname(os.path.abspath(path)) or "."
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=".regstate-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def append_record(path: str, payload: dict) -> None:
+    """Append one JSON object as a single line to the NDJSON stream at *path*.
+
+    Creates a stream header first if the file does not exist yet, so every
+    stream is self-describing even when the first writer is a case runner
+    rather than the suite driver.
+    """
+    directory = os.path.dirname(os.path.abspath(path)) or "."
+    os.makedirs(directory, exist_ok=True)
+    if not os.path.exists(path):
+        _append_line(path, _header_record({}))
+    _append_line(path, payload)
+
+
+def _append_line(path: str, payload: dict) -> None:
+    """One `write(2)` of one JSON line to an `O_APPEND` descriptor."""
+    data = (json.dumps(payload, ensure_ascii=True, separators=(",", ":")) + "\n").encode(
+        "utf-8"
+    )
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+    try:
+        written = os.write(fd, data)
+        # A regular file in append mode writes fully in practice; finish the
+        # job rather than silently dropping the tail if it ever does not.
+        while written < len(data):
+            written += os.write(fd, data[written:])
+    finally:
+        os.close(fd)
+
+
+def _header_record(fields: dict) -> dict:
+    record = {
+        "schema_version": SCHEMA_VERSION,
+        "record": "stream_header",
+        "created_at": _now_iso(),
+    }
+    record.update(fields)
+    return record
+
+
+# -- subcommands -------------------------------------------------------------
+
+
+def cmd_header(args: argparse.Namespace) -> int:
+    """Write a stream header, unless the stream already exists."""
+    fields = collect_fields(args)
+    for stream in args.stream:
+        if os.path.exists(stream):
+            continue
+        directory = os.path.dirname(os.path.abspath(stream)) or "."
+        os.makedirs(directory, exist_ok=True)
+        _append_line(stream, _header_record(fields))
+    return 0
+
+
+def cmd_event(args: argparse.Namespace) -> int:
+    """Append one event to each requested stream."""
+    record = {
+        "schema_version": SCHEMA_VERSION,
+        "record": "event",
+        "event": args.type,
+        "ts": _now_iso(),
+    }
+    record.update(collect_fields(args))
+    for stream in args.stream:
+        append_record(stream, record)
+    return 0
+
+
+def cmd_snapshot(args: argparse.Namespace) -> int:
+    """Atomically replace a snapshot document."""
+    record = {
+        "schema_version": SCHEMA_VERSION,
+        "record": args.record,
+        "updated_at": _now_iso(),
+    }
+    record.update(collect_fields(args))
+    write_json_atomic(args.path, record)
+    return 0
+
+
+def cmd_result(args: argparse.Namespace) -> int:
+    """Atomically write a terminal result document.
+
+    The status is derived from the raw exit code by the same rule the shell
+    uses, so the two representations cannot disagree. `--status` exists for the
+    cases where the driver knows more than the exit code does (a synthesised
+    result for a child that died before writing its own).
+    """
+    exit_code = args.exit_code
+    record: dict = {
+        "schema_version": SCHEMA_VERSION,
+        "record": "result",
+        "status": args.status or classify(exit_code),
+        "exit_code": exit_code,
+    }
+    if exit_code > 128:
+        number = exit_code - 128
+        record["signal"] = number
+        record["signal_name"] = signal_name(number)
+    if args.suite_id:
+        record["suite_id"] = args.suite_id
+    if args.case_id:
+        record["case_id"] = args.case_id
+    if args.started_epoch is not None:
+        record["started_at"] = _iso_from_epoch(args.started_epoch)
+    if args.ended_epoch is not None:
+        record["ended_at"] = _iso_from_epoch(args.ended_epoch)
+    if args.started_epoch is not None and args.ended_epoch is not None:
+        record["elapsed_s"] = round(args.ended_epoch - args.started_epoch, 3)
+    if args.phase:
+        record["phase"] = args.phase
+    if args.message:
+        record["message"] = _truncate(args.message)
+    if args.runner:
+        record["runner"] = args.runner
+    record.update(collect_fields(args))
+    write_json_atomic(args.path, record)
+    return 0
+
+
+def _zip_cases(ids: list[str], tags: list[str] | None, codes: list[str] | None) -> list[tuple]:
+    """Pair up the parallel per-case option lists, refusing ragged input.
+
+    The drivers pass per-case data as repeated `--case-id` / `--case-tag` /
+    `--case-exit-code` options rather than a packed delimiter format, so a case
+    path containing any character at all is safe. argparse preserves the order
+    within one option, so zipping by index is well defined — but only if the
+    lists are the same length, which is worth failing loudly on.
+    """
+    for name, other in (("--case-tag", tags), ("--case-exit-code", codes)):
+        if other is not None and len(other) != len(ids):
+            raise SystemExit(
+                f"regressionState.py: {len(ids)} --case-id but {len(other)} {name}"
+            )
+    return list(
+        zip(
+            ids,
+            tags if tags is not None else [""] * len(ids),
+            codes if codes is not None else [""] * len(ids),
+        )
+    )
+
+
+def cmd_listing(args: argparse.Namespace) -> int:
+    """Emit the machine-readable case manifest for a suite selection.
+
+    This is the contract an external observer reads *before* a run to learn
+    which cases the driver selected, without reimplementing the driver's tag
+    and `--case` filter rules. `id` is the case-list relative path (not the
+    basename) so duplicate basenames cannot collide.
+    """
+    cases = []
+    for case_id, tag, _ in _zip_cases(args.case_id or [], args.case_tag, None):
+        entry = {
+            "id": case_id,
+            "name": os.path.basename(case_id.rstrip("/")),
+            "path": os.path.join(args.project_root, case_id)
+            if args.project_root
+            else case_id,
+            "runner": args.runner,
+        }
+        if tag:
+            entry["tag"] = tag
+        cases.append(entry)
+
+    document = {
+        "schema_version": SCHEMA_VERSION,
+        "record": args.record,
+        "suite": args.suite,
+        "driver": args.driver,
+        "project_root": args.project_root,
+        "cases": cases,
+    }
+    document.update(collect_fields(args))
+
+    if args.out:
+        write_json_atomic(args.out, document)
+    else:
+        json.dump(document, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    return 0
+
+
+def cmd_suite_result(args: argparse.Namespace) -> int:
+    """Write the final suite result, folding in each case's own result file.
+
+    Each case's terminal result is written by the case runner, which is the
+    authority on what that case did. This command aggregates them in the order
+    the driver selected, and — crucially — does not treat an absent case result
+    as a pass: when a runner died before writing one, the driver's observed wait
+    status is used to synthesise `ERROR`/`TIMEOUT`/`CRASH` instead.
+    """
+    cases = []
+    counts: dict[str, int] = {}
+    for case_id, _, observed in _zip_cases(
+        args.case_id or [], None, args.case_exit_code
+    ):
+        entry = _case_result_entry(args.cases_root, case_id, observed)
+        counts[entry["status"]] = counts.get(entry["status"], 0) + 1
+        cases.append(entry)
+
+    document = {
+        "schema_version": SCHEMA_VERSION,
+        "record": "result",
+        "suite": args.suite,
+        "driver": args.driver,
+        "status": args.status or classify(args.exit_code),
+        "exit_code": args.exit_code,
+    }
+    if args.started_epoch is not None:
+        document["started_at"] = _iso_from_epoch(args.started_epoch)
+    if args.ended_epoch is not None:
+        document["ended_at"] = _iso_from_epoch(args.ended_epoch)
+    if args.started_epoch is not None and args.ended_epoch is not None:
+        document["elapsed_s"] = round(args.ended_epoch - args.started_epoch, 3)
+    document["n_cases"] = len(cases)
+    document["counts"] = counts
+    document["cases"] = cases
+    document.update(collect_fields(args))
+    write_json_atomic(args.path, document)
+    return 0
+
+
+def _case_result_entry(cases_root: str, case_id: str, observed: str) -> dict:
+    """Build one aggregated case entry for the suite result.
+
+    Prefers the case's own `result.json`. Falls back to the driver's observed
+    exit code, and flags a disagreement rather than quietly trusting the file —
+    a stale result left over from an earlier run must not be able to turn a
+    crashed case green.
+    """
+    observed_code: int | None
+    try:
+        observed_code = int(observed)
+    except (TypeError, ValueError):
+        observed_code = None
+
+    path = os.path.join(cases_root, case_id, "result.json") if cases_root else ""
+    payload = None
+    if path and os.path.isfile(path):
+        try:
+            with open(path, encoding="utf-8") as handle:
+                payload = json.load(handle)
+        except (OSError, ValueError):
+            payload = None
+
+    if payload is None:
+        entry = {
+            "id": case_id,
+            "status": classify(observed_code) if observed_code is not None else ERROR,
+            "exit_code": observed_code if observed_code is not None else 2,
+            "message": "no case result written — status derived from the runner's exit status",
+            "result_file": path or None,
+        }
+        if entry["exit_code"] > 128:
+            number = entry["exit_code"] - 128
+            entry["signal"] = number
+            entry["signal_name"] = signal_name(number)
+        return entry
+
+    entry = {key: value for key, value in payload.items()
+             if key not in ("schema_version", "record")}
+    entry["id"] = case_id
+    entry["result_file"] = path
+    if observed_code is not None and payload.get("exit_code") != observed_code:
+        # The runner's own file disagrees with what the driver waited on. Trust
+        # the wait status and say so, so a stale file is visible, not silent.
+        entry["result_mismatch"] = {
+            "recorded_exit_code": payload.get("exit_code"),
+            "observed_exit_code": observed_code,
+        }
+        entry["status"] = classify(observed_code)
+        entry["exit_code"] = observed_code
+    return entry
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="regressionState.py",
+        description="Emit PGF regression run state as JSON / NDJSON.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_header = sub.add_parser("header", help="write a stream header if absent")
+    p_header.add_argument("--stream", action="append", required=True, metavar="PATH")
+    add_field_options(p_header)
+    p_header.set_defaults(func=cmd_header)
+
+    p_event = sub.add_parser("event", help="append one event to one or more streams")
+    p_event.add_argument("--type", required=True, help="event name, e.g. case_started")
+    p_event.add_argument("--stream", action="append", required=True, metavar="PATH")
+    add_field_options(p_event)
+    p_event.set_defaults(func=cmd_event)
+
+    p_snap = sub.add_parser("snapshot", help="atomically write a JSON snapshot")
+    p_snap.add_argument("--path", required=True, metavar="PATH")
+    p_snap.add_argument("--record", default="snapshot", help="record discriminator")
+    add_field_options(p_snap)
+    p_snap.set_defaults(func=cmd_snapshot)
+
+    p_res = sub.add_parser("result", help="atomically write a terminal result")
+    p_res.add_argument("--path", required=True, metavar="PATH")
+    p_res.add_argument("--exit-code", type=int, required=True)
+    p_res.add_argument("--status", default="", help="override the derived status")
+    p_res.add_argument("--suite-id", default="")
+    p_res.add_argument("--case-id", default="")
+    p_res.add_argument("--phase", default="", help="phase the case was in at exit")
+    p_res.add_argument("--message", default="")
+    p_res.add_argument("--runner", default="", help="native runner name")
+    p_res.add_argument("--started-epoch", type=float, default=None)
+    p_res.add_argument("--ended-epoch", type=float, default=None)
+    add_field_options(p_res)
+    p_res.set_defaults(func=cmd_result)
+
+    p_list = sub.add_parser("listing", help="emit a suite's selected-case manifest")
+    p_list.add_argument("--suite", default="", help="suite name, e.g. regression")
+    p_list.add_argument("--driver", default="", help="driver name, e.g. Allrun")
+    p_list.add_argument("--project-root", default="", help="root case paths are relative to")
+    p_list.add_argument("--runner", default="", help="per-case runner name")
+    p_list.add_argument("--record", default="listing", help="record discriminator")
+    p_list.add_argument("--out", default="", help="write here instead of stdout")
+    p_list.add_argument("--case-id", action="append", metavar="ID")
+    p_list.add_argument("--case-tag", action="append", metavar="TAG")
+    add_field_options(p_list)
+    p_list.set_defaults(func=cmd_listing)
+
+    p_suite = sub.add_parser("suite-result", help="write the aggregated suite result")
+    p_suite.add_argument("--path", required=True, metavar="PATH")
+    p_suite.add_argument("--exit-code", type=int, required=True)
+    p_suite.add_argument("--status", default="", help="override the derived status")
+    p_suite.add_argument("--suite", default="")
+    p_suite.add_argument("--driver", default="")
+    p_suite.add_argument("--cases-root", default="", help="dir holding cases/<id>/result.json")
+    p_suite.add_argument("--case-id", action="append", metavar="ID")
+    p_suite.add_argument("--case-exit-code", action="append", metavar="N",
+                         help="exit status the driver waited on, per --case-id")
+    p_suite.add_argument("--started-epoch", type=float, default=None)
+    p_suite.add_argument("--ended-epoch", type=float, default=None)
+    add_field_options(p_suite)
+    p_suite.set_defaults(func=cmd_suite_result)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return args.func(args)
+    except SystemExit:
+        raise
+    except OSError as exc:
+        print(f"regressionState.py: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/applications/test/regression/tools/runCase.sh
+++ b/applications/test/regression/tools/runCase.sh
@@ -2,8 +2,30 @@
 # Run one regression case and compare its postProcessing/ output against the
 # committed reference/postProcessing/ baseline.
 #
+# This is a supported entry point: it may be called directly on a single case,
+# or by applications/test/regression/Allrun for a whole suite. Either way this
+# script — not its caller, and not any external tool — owns the serial case
+# lifecycle: the checked Allclean, the clean-slate assertion, the case's own
+# ./Allrun, and the numerical comparison.
+#
 # Usage:
 #   runCase.sh <caseDir> [--no-run] [--rtol R] [--atol A] [--compare PATH]
+#              [--state-dir DIR] [--suite-events PATH]
+#              [--case-id ID] [--suite-id ID]
+#
+# Options:
+#   --no-run          Skip cleaning and running; compare existing output only.
+#   --rtol R          Relative tolerance for the comparator.
+#   --atol A          Absolute tolerance for the comparator.
+#   --compare PATH    Comparator to use (default: sibling compareScalars.py).
+#   --state-dir DIR   Write structured run state for this case into DIR
+#                     (state.json, events.ndjson, result.json, compare logs).
+#                     Optional: without it nothing extra is written and the
+#                     script behaves exactly as it always has.
+#   --suite-events P  Additionally append this case's events to the suite-level
+#                     NDJSON stream at P, so one stream can be tailed.
+#   --case-id ID      Case id recorded in state (default: the case basename).
+#   --suite-id ID     Suite id recorded in state (default: empty).
 #
 # Exit codes (shared outcome taxonomy — see tools/regressionLib.sh):
 #   0      - PASS  (ran, compared, within tolerance)
@@ -11,14 +33,28 @@
 #   2      - ERROR (infrastructure: missing files, dirty slate, run failure)
 #   128+N  - CRASH (the case Allrun/solver died on signal N; propagated as-is so
 #                   the runner reports e.g. CRASH (SIGABRT) for a 134 abort)
+#
+# The exit code is the contract. The JSON written under --state-dir is an
+# additional representation of the same outcome, never a substitute for it.
 
 set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Shared outcome taxonomy + run-state helpers (reg_state, reg_event). The
+# library sources helpers.sh internally.
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/regressionLib.sh"
 
 caseDir=""
 SKIP_RUN=false
 RTOL="1e-4"
 ATOL="1e-12"
 COMPARE=""
+STATE_DIR=""
+SUITE_EVENTS=""
+CASE_ID=""
+SUITE_ID=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -38,6 +74,22 @@ while [ $# -gt 0 ]; do
         COMPARE="$2"
         shift 2
         ;;
+    --state-dir)
+        STATE_DIR="$2"
+        shift 2
+        ;;
+    --suite-events)
+        SUITE_EVENTS="$2"
+        shift 2
+        ;;
+    --case-id)
+        CASE_ID="$2"
+        shift 2
+        ;;
+    --suite-id)
+        SUITE_ID="$2"
+        shift 2
+        ;;
     -*)
         echo "Unknown option: $1" >&2
         exit 2
@@ -52,40 +104,129 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -z "$caseDir" ] || [ ! -d "$caseDir" ]; then
-    echo "Case directory not found: $caseDir" >&2
-    exit 2
+# -- run-state plumbing (inert unless --state-dir was given) -------------------
+
+CASE_STATE=""
+CASE_RESULT=""
+COMPARE_LOG=""
+COMPARE_ERR=""
+PHASE="queued"
+T_START=$(date +%s)
+RESULT_FIELDS=()
+
+[ -n "$CASE_ID" ] || CASE_ID="$(basename "${caseDir:-unknown}")"
+
+if [ -n "$STATE_DIR" ]; then
+    if ! mkdir -p "$STATE_DIR"; then
+        echo "[runCase] cannot create state directory: $STATE_DIR" >&2
+        exit 2
+    fi
+    CASE_STATE="$STATE_DIR/state.json"
+    CASE_RESULT="$STATE_DIR/result.json"
+    COMPARE_LOG="$STATE_DIR/compare.log"
+    COMPARE_ERR="$STATE_DIR/compare.err.log"
+    REG_EVENT_STREAMS=("$STATE_DIR/events.ndjson")
+    [ -n "$SUITE_EVENTS" ] && REG_EVENT_STREAMS+=("$SUITE_EVENTS")
 fi
 
+# reg_phase <phase> — record entry into a lifecycle phase.
+#   Phases for this runner: clean, run, assert, compare (plus the queued state
+#   before the first one). The phase is carried into the terminal result so a
+#   failure says *where* it happened, not just that it happened.
+reg_phase() {
+    PHASE="$1"
+    reg_event case_phase --field "case_id=$CASE_ID" --field "phase=$1"
+    [ -n "$CASE_STATE" ] || return 0
+    reg_state snapshot --path "$CASE_STATE" \
+        --field "case_id=$CASE_ID" \
+        --field "suite_id=$SUITE_ID" \
+        --field "phase=$1" \
+        --field "case_dir=$caseDir" \
+        --field "runner=runCase.sh" \
+        --num "started_epoch=$T_START"
+}
+
+# finish <exit-code> [message] — write the terminal result, then exit with the
+#   code. Every exit path goes through here so no path can end without either a
+#   result file or (when the process dies outright) the driver noticing that one
+#   is missing.
+finish() {
+    local rc="$1" msg="${2:-}" t_end
+    t_end=$(date +%s)
+    if [ -n "$CASE_RESULT" ]; then
+        reg_state result --path "$CASE_RESULT" \
+            --exit-code "$rc" \
+            --case-id "$CASE_ID" \
+            --suite-id "$SUITE_ID" \
+            --phase "$PHASE" \
+            --message "$msg" \
+            --runner runCase.sh \
+            --started-epoch "$T_START" \
+            --ended-epoch "$t_end" \
+            "${RESULT_FIELDS[@]}"
+    fi
+    reg_event case_finished \
+        --field "case_id=$CASE_ID" \
+        --int "exit_code=$rc" \
+        --field "status=$(reg_classify "$rc")" \
+        --field "phase=$PHASE" \
+        --field "message=$msg"
+    exit "$rc"
+}
+
+# -- validation ---------------------------------------------------------------
+
+if [ -z "$caseDir" ] || [ ! -d "$caseDir" ]; then
+    echo "Case directory not found: $caseDir" >&2
+    finish 2 "case directory not found: $caseDir"
+fi
+
+caseDir="$(cd "$caseDir" && pwd)"
+RESULT_FIELDS+=(--artifact "case_dir=$caseDir")
+[ -n "$COMPARE_LOG" ] && RESULT_FIELDS+=(--artifact "compare_log=$COMPARE_LOG")
+
 if [ -z "$COMPARE" ]; then
-    COMPARE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compareScalars.py"
+    COMPARE="$SCRIPT_DIR/compareScalars.py"
 fi
 
 if [ ! -x "$COMPARE" ] && [ ! -f "$COMPARE" ]; then
     echo "Comparator not found: $COMPARE" >&2
-    exit 2
+    finish 2 "comparator not found: $COMPARE"
 fi
+
+reg_event case_started \
+    --field "case_id=$CASE_ID" \
+    --field "suite_id=$SUITE_ID" \
+    --field "case_dir=$caseDir" \
+    --field "runner=runCase.sh" \
+    --bool "no_run=$SKIP_RUN" \
+    --field "rtol=$RTOL" \
+    --field "atol=$ATOL"
+
+# -- clean + run --------------------------------------------------------------
 
 if [ "$SKIP_RUN" = false ]; then
     if [ ! -x "$caseDir/Allrun" ]; then
         echo "$caseDir/Allrun is missing or not executable" >&2
-        exit 2
+        finish 2 "$caseDir/Allrun is missing or not executable"
     fi
 
     # Clean prior run artefacts (preserve reference/). A swallowed clean can
     # leave a dirty slate that silently corrupts the comparison, so the clean
     # is checked and the slate is asserted afterwards.
+    reg_phase clean
     if [ -x "$caseDir/Allclean" ]; then
         if ! (cd "$caseDir" && ./Allclean) >/dev/null 2>&1; then
             echo "[runCase] Allclean failed in $caseDir" >&2
-            exit 2
+            finish 2 "Allclean failed in $caseDir"
         fi
     fi
     if ls "$caseDir"/log.* >/dev/null 2>&1 || [ -d "$caseDir/postProcessing" ]; then
         echo "[runCase] dirty slate: log.*/postProcessing survived the clean in $caseDir" >&2
-        exit 2
+        finish 2 "dirty slate: log.*/postProcessing survived the clean in $caseDir"
     fi
 
+    reg_phase run
     echo "[runCase] Running $caseDir/Allrun"
     (cd "$caseDir" && ./Allrun)
     rc=$?
@@ -96,21 +237,78 @@ if [ "$SKIP_RUN" = false ]; then
     if [ "$rc" -ne 0 ]; then
         if [ "$rc" -gt 128 ]; then
             echo "[runCase] Allrun in $caseDir died on signal $(( rc - 128 )) (exit $rc)" >&2
+            finish "$rc" "Allrun died on signal $(( rc - 128 )) ($(reg_signal_name $(( rc - 128 ))))"
         else
             echo "[runCase] Allrun in $caseDir exited non-zero ($rc)" >&2
+            finish "$rc" "Allrun exited non-zero ($rc)"
         fi
-        exit "$rc"
     fi
 fi
 
+# -- output assertions --------------------------------------------------------
+
+reg_phase assert
+
 if [ ! -d "$caseDir/postProcessing" ]; then
     echo "[runCase] No postProcessing/ produced under $caseDir" >&2
-    exit 2
+    finish 2 "no postProcessing/ produced under $caseDir"
 fi
 
 if [ ! -d "$caseDir/reference/postProcessing" ]; then
     echo "[runCase] No reference baseline at $caseDir/reference/postProcessing" >&2
-    exit 2
+    finish 2 "no reference baseline at $caseDir/reference/postProcessing"
+fi
+
+RESULT_FIELDS+=(
+    --artifact "candidate=$caseDir/postProcessing"
+    --artifact "reference=$caseDir/reference/postProcessing"
+)
+
+# -- comparison ---------------------------------------------------------------
+
+reg_phase compare
+
+if [ -n "$STATE_DIR" ]; then
+    # State mode captures the comparator's streams so the counts it reports are
+    # machine-readable, then replays them so the terminal output is unchanged.
+    # No pipe: the comparator's exit status stays this script's own.
+    python3 "$COMPARE" \
+        --reference "$caseDir/reference/postProcessing" \
+        --candidate "$caseDir/postProcessing" \
+        --rtol "$RTOL" \
+        --atol "$ATOL" >"$COMPARE_LOG" 2>"$COMPARE_ERR"
+    rc=$?
+    cat "$COMPARE_LOG"
+    cat "$COMPARE_ERR" >&2
+
+    # "compareScalars.py: <within>/<total> files within tolerance (...)" and,
+    # when applicable, "compareScalars.py: <n> reference file(s) not present".
+    nTotal=0; nWithin=0; nMissing=0
+    line="$(grep -m1 'files within tolerance' "$COMPARE_LOG" || true)"
+    if [[ "$line" =~ ([0-9]+)/([0-9]+)[[:space:]]+files[[:space:]]+within ]]; then
+        nWithin="${BASH_REMATCH[1]}"
+        nTotal="${BASH_REMATCH[2]}"
+    fi
+    line="$(grep -m1 'not present in candidate' "$COMPARE_LOG" || true)"
+    if [[ "$line" =~ ([0-9]+)[[:space:]]+reference[[:space:]]+file ]]; then
+        nMissing="${BASH_REMATCH[1]}"
+    fi
+    nFailed=$(( nTotal - nWithin - nMissing ))
+    [ "$nFailed" -lt 0 ] && nFailed=0
+    RESULT_FIELDS+=(
+        --int "compare_files_total=$nTotal"
+        --int "compare_files_passed=$nWithin"
+        --int "compare_files_failed=$nFailed"
+        --int "compare_files_missing=$nMissing"
+    )
+    if [ "$rc" -eq 0 ]; then
+        msg="comparison within tolerance ($nWithin/$nTotal files)"
+    elif [ "$rc" -eq 1 ]; then
+        msg="comparison diverged ($nFailed out of tolerance, $nMissing missing of $nTotal)"
+    else
+        msg="comparator reported an infrastructure error (exit $rc)"
+    fi
+    finish "$rc" "$msg"
 fi
 
 python3 "$COMPARE" \
@@ -118,3 +316,4 @@ python3 "$COMPARE" \
     --candidate "$caseDir/postProcessing" \
     --rtol "$RTOL" \
     --atol "$ATOL"
+finish $? ""

--- a/applications/test/regression/tools/runDEMCase.sh
+++ b/applications/test/regression/tools/runDEMCase.sh
@@ -1,67 +1,245 @@
 #!/bin/bash
-# Test-mode runner for a single DEM/Yade case. Called by Allrun.yade — not for direct use.
-# Usage: runDEMCase.sh <abs-path-to-case-dir>
+# Test-mode runner for a single DEM/Yade case.
+#
+# This is a supported entry point: it may be called directly on one DEM case,
+# or by applications/test/regression/Allrun.yade for the whole DEM suite. The
+# test-mode controls (step cap, wall-clock bound) and the output assertions live
+# here rather than in the tutorial Allrun scripts, so a tutorial stays a
+# tutorial and this script stays the authority on what a DEM case must produce.
+#
+# Usage:
+#   runDEMCase.sh <caseDir> [--timeout SECONDS] [--nsteps N]
+#                 [--state-dir DIR] [--suite-events PATH]
+#                 [--case-id ID] [--suite-id ID]
+#
+# Options:
+#   --timeout S       Wall-clock bound for the run (overrides $YADE_TIMEOUT).
+#   --nsteps N        DEM step cap (overrides $YADE_NSTEPS).
+#   --state-dir DIR   Write structured run state for this case into DIR
+#                     (state.json, events.ndjson, result.json). Optional:
+#                     without it nothing extra is written and the script behaves
+#                     exactly as it always has.
+#   --suite-events P  Additionally append this case's events to the suite-level
+#                     NDJSON stream at P, so one stream can be tailed.
+#   --case-id ID      Case id recorded in state (default: the case basename).
+#   --suite-id ID     Suite id recorded in state (default: empty).
+#
+# Environment (a CLI option wins over the variable):
+#   YADE_NSTEPS       DEM step cap                          (default 2000000)
+#   YADE_TIMEOUT      wall-clock bound in seconds           (default 3600)
+#   YADE_KILL_GRACE   TERM-to-KILL grace for the timeout    (default 30)
 #
 # Exit codes (shared outcome taxonomy — see regressionLib.sh):
 #   0      - PASS  (ran to completion, all output asserts satisfied)
 #   1      - FAIL  (ran, but an output assert failed: no RUN FINISH / VTK / dt)
-#   124    - TIMEOUT (the run exceeded YADE_TIMEOUT and its process group was
+#   2      - ERROR (infrastructure: missing case dir, failed clean)
+#   124    - TIMEOUT (the run exceeded the timeout and its process group was
 #                     terminated)
 #   128+N  - CRASH (the run process group died on signal N)
+#
+# The exit code is the contract. The JSON written under --state-dir is an
+# additional representation of the same outcome, never a substitute for it.
+
 set -u
 
-CASE_DIR="${1:-}"
-if [ -z "$CASE_DIR" ] || [ ! -d "$CASE_DIR" ]; then
-    echo "ERROR: case directory not found: $CASE_DIR" >&2
-    exit 2
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-NSTEPS="${YADE_NSTEPS:-2000000}"
-TIMEOUT="${YADE_TIMEOUT:-3600}"
+# Shared outcome taxonomy + run-state helpers (reg_state, reg_event).
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/regressionLib.sh"
+
+CASE_DIR=""
+OPT_TIMEOUT=""
+OPT_NSTEPS=""
+STATE_DIR=""
+SUITE_EVENTS=""
+CASE_ID=""
+SUITE_ID=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --timeout)
+        OPT_TIMEOUT="$2"
+        shift 2
+        ;;
+    --nsteps)
+        OPT_NSTEPS="$2"
+        shift 2
+        ;;
+    --state-dir)
+        STATE_DIR="$2"
+        shift 2
+        ;;
+    --suite-events)
+        SUITE_EVENTS="$2"
+        shift 2
+        ;;
+    --case-id)
+        CASE_ID="$2"
+        shift 2
+        ;;
+    --suite-id)
+        SUITE_ID="$2"
+        shift 2
+        ;;
+    -*)
+        echo "Unknown option: $1" >&2
+        exit 2
+        ;;
+    *)
+        if [ -z "$CASE_DIR" ]; then CASE_DIR="$1"; else
+            echo "Unexpected positional: $1" >&2
+            exit 2
+        fi
+        shift
+        ;;
+    esac
+done
+
+NSTEPS="${OPT_NSTEPS:-${YADE_NSTEPS:-2000000}}"
+TIMEOUT="${OPT_TIMEOUT:-${YADE_TIMEOUT:-3600}}"
 # Grace period between the timeout TERM and the follow-up KILL, to let MPI tear
 # down cleanly before the group is force-killed.
 KILL_GRACE="${YADE_KILL_GRACE:-30}"
 
-cd "$CASE_DIR" || { echo "ERROR: cannot cd into $CASE_DIR" >&2; exit 2; }
+# -- run-state plumbing (inert unless --state-dir was given) -------------------
+
+CASE_STATE=""
+CASE_RESULT=""
+PHASE="queued"
+T_START=$(date +%s)
+RESULT_FIELDS=()
+
+[ -n "$CASE_ID" ] || CASE_ID="$(basename "${CASE_DIR:-unknown}")"
+
+if [ -n "$STATE_DIR" ]; then
+    if ! mkdir -p "$STATE_DIR"; then
+        echo "ERROR: cannot create state directory: $STATE_DIR" >&2
+        exit 2
+    fi
+    CASE_STATE="$STATE_DIR/state.json"
+    CASE_RESULT="$STATE_DIR/result.json"
+    REG_EVENT_STREAMS=("$STATE_DIR/events.ndjson")
+    [ -n "$SUITE_EVENTS" ] && REG_EVENT_STREAMS+=("$SUITE_EVENTS")
+fi
+
+# reg_phase <phase> — record entry into a lifecycle phase (clean, run, assert).
+reg_phase() {
+    PHASE="$1"
+    reg_event case_phase --field "case_id=$CASE_ID" --field "phase=$1"
+    [ -n "$CASE_STATE" ] || return 0
+    reg_state snapshot --path "$CASE_STATE" \
+        --field "case_id=$CASE_ID" \
+        --field "suite_id=$SUITE_ID" \
+        --field "phase=$1" \
+        --field "case_dir=$CASE_DIR" \
+        --field "runner=runDEMCase.sh" \
+        --num "started_epoch=$T_START"
+}
+
+# finish <exit-code> [message] — write the terminal result, then exit with it.
+finish() {
+    local rc="$1" msg="${2:-}" t_end
+    t_end=$(date +%s)
+    if [ -n "$CASE_RESULT" ]; then
+        reg_state result --path "$CASE_RESULT" \
+            --exit-code "$rc" \
+            --case-id "$CASE_ID" \
+            --suite-id "$SUITE_ID" \
+            --phase "$PHASE" \
+            --message "$msg" \
+            --runner runDEMCase.sh \
+            --started-epoch "$T_START" \
+            --ended-epoch "$t_end" \
+            "${RESULT_FIELDS[@]}"
+    fi
+    reg_event case_finished \
+        --field "case_id=$CASE_ID" \
+        --int "exit_code=$rc" \
+        --field "status=$(reg_classify "$rc")" \
+        --field "phase=$PHASE" \
+        --field "message=$msg"
+    exit "$rc"
+}
+
+# -- validation ---------------------------------------------------------------
+
+if [ -z "$CASE_DIR" ] || [ ! -d "$CASE_DIR" ]; then
+    echo "ERROR: case directory not found: $CASE_DIR" >&2
+    finish 2 "case directory not found: $CASE_DIR"
+fi
+
+CASE_DIR="$(cd "$CASE_DIR" && pwd)"
+RESULT_FIELDS+=(
+    --artifact "case_dir=$CASE_DIR"
+    --artifact "run_log=$CASE_DIR/run.log"
+)
+
+cd "$CASE_DIR" || { echo "ERROR: cannot cd into $CASE_DIR" >&2; finish 2 "cannot cd into $CASE_DIR"; }
+
+reg_event case_started \
+    --field "case_id=$CASE_ID" \
+    --field "suite_id=$SUITE_ID" \
+    --field "case_dir=$CASE_DIR" \
+    --field "runner=runDEMCase.sh" \
+    --int "nsteps=$NSTEPS" \
+    --int "timeout_s=$TIMEOUT"
+
+# -- clean --------------------------------------------------------------------
 
 # Checked clean (no swallowed failure): a broken clean leaves a dirty slate that
 # would corrupt the run's output asserts.
+reg_phase clean
 if [ -x ./Allclean ]; then
     if ! ./Allclean > /dev/null 2>&1; then
         echo "ERROR: Allclean failed in $CASE_DIR" >&2
-        exit 2
+        finish 2 "Allclean failed in $CASE_DIR"
     fi
 fi
 
+# -- run ----------------------------------------------------------------------
+
+reg_phase run
 echo "  running DEM simulation (NSTEPS=$NSTEPS, timeout=${TIMEOUT}s)..."
 # Run the case in its own session/process group (setsid) under timeout, so a
 # hung run and its whole tree (mpirun -> yade -> MPI_Comm_spawn'd solver) are
 # terminated by signalling THAT group only. This replaces a host-wide
 # `pkill -f porousGasificationFoam`, which would kill unrelated solver runs
 # elsewhere on the machine. No `|| true`: the run's exit status is classified.
+YADE_NSTEPS="$NSTEPS" \
 setsid timeout --kill-after="$KILL_GRACE" "$TIMEOUT" bash ./Allrun > run.log 2>&1
 rc=$?
 if [ "$rc" -eq 124 ]; then
     echo "ERROR: DEM run exceeded ${TIMEOUT}s — process group terminated (TIMEOUT)"
-    exit 124
+    finish 124 "DEM run exceeded ${TIMEOUT}s — process group terminated"
 elif [ "$rc" -gt 128 ]; then
     echo "ERROR: DEM run died on signal $(( rc - 128 )) (CRASH)"
-    exit "$rc"
+    finish "$rc" "DEM run died on signal $(( rc - 128 )) ($(reg_signal_name $(( rc - 128 ))))"
 elif [ "$rc" -ne 0 ]; then
     echo "ERROR: DEM run launcher exited non-zero ($rc) — check run.log"
-    exit "$rc"
+    finish "$rc" "DEM run launcher exited non-zero ($rc) — check run.log"
 fi
 
+# -- output assertions --------------------------------------------------------
+
+reg_phase assert
+
 grep -q "RUN FINISH" run.log \
-    || { echo "ERROR: simulation did not complete — check run.log"; exit 1; }
+    || { echo "ERROR: simulation did not complete — check run.log"; finish 1 "simulation did not complete (no RUN FINISH in run.log)"; }
 grep -q "DEM coupling: active" run.log \
-    || { echo "ERROR: DEM coupling not active — solver built without -DWITH_YADE=1?"; exit 1; }
-ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; exit 1; }
-ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; exit 1; }
+    || { echo "ERROR: DEM coupling not active — solver built without -DWITH_YADE=1?"; finish 1 "DEM coupling not active — solver built without -DWITH_YADE=1?"; }
+ls spheres/spheres_*.vtp > /dev/null 2>&1 || { echo "ERROR: no sphere VTK files written"; finish 1 "no sphere VTK files written"; }
+ls springs/springs_*.vtp > /dev/null 2>&1 || { echo "ERROR: no spring VTK files written"; finish 1 "no spring VTK files written"; }
 echo "  DEM output check passed"
 
+RESULT_FIELDS+=(
+    --artifact "spheres=$CASE_DIR/spheres"
+    --artifact "springs=$CASE_DIR/springs"
+    --artifact "dt_info=$CASE_DIR/dtInfo.txt"
+)
+
 [ -f dtInfo.txt ] \
-    || { echo "ERROR: dtInfo.txt not written — did the run reach iter 1?"; exit 1; }
+    || { echo "ERROR: dtInfo.txt not written — did the run reach iter 1?"; finish 1 "dtInfo.txt not written — did the run reach iter 1?"; }
 if ! python3 - <<'PYCHECK'
 import sys
 lines = [l for l in open("dtInfo.txt") if not l.startswith("iter") and l.strip()]
@@ -72,4 +250,6 @@ if foamDt <= 0.0:
     print("ERROR: foamDt={:.3e} — PGF time step not received".format(foamDt)); sys.exit(1)
 print("  PGF coupling check passed (foamDt={:.3e})".format(foamDt))
 PYCHECK
-then exit 1; fi
+then finish 1 "dtInfo.txt assertion failed — no positive PGF time step received"; fi
+
+finish 0 "DEM run completed; coupling, VTK and dtInfo assertions satisfied"


### PR DESCRIPTION
## Summary

Gives the regression suites a public interface: `--jobs N` for suite-owned bounded concurrency, `--list --json` for a machine-readable manifest of the selected cases, and `--state-dir DIR` for structured run state an external observer can read while a run is in progress. Both per-case runners become supported direct entry points. No case input, baseline or solver source is touched.

The default `./Allrun` is unchanged — same case order, same outcomes, same output — and the scripts still need nothing but bash, `python3` and OpenFOAM.

## Why

The suite had no way to say what it was doing except human log output, so anything wanting to watch a run (CI, a dashboard) had to re-implement case selection, cleaning, execution and comparison to find out — a second engine that would eventually disagree with this one about what a case did. And a 19-case tier that runs strictly one at a time leaves most of a machine idle.

Both are addressed without moving any authority out of these scripts. The driver still decides which cases belong to a suite, how they are filtered and cleaned, what each case's own `Allrun` does, how output is compared, how outcomes are classified, and what the suite's exit status is. The new JSON is an *additional* representation of the same outcome; the exit code remains the contract.

Two properties are deliberate and load-bearing:

- **Selection is one code path.** `--list` and a real run apply the same filter function, so a listing cannot disagree with what subsequently runs.
- **An absent result is never a pass.** If a runner dies before writing one, the driver synthesises the outcome from the wait status it observed; if a case's own `result.json` disagrees with that status, the observed status wins and the disagreement is recorded (`result_mismatch`), so a stale file from an earlier run cannot turn a crash green. A driver drops any previous result before launching a case.

`--jobs` is suite concurrency, not decomposition: it never becomes an MPI rank count, never touches `decomposeParDict`, and never changes how a case invokes its solver — that is part of the procedure under test and lives in the case's own `Allrun`.

### Behaviour changes worth flagging

| Change | Was | Now |
|---|---|---|
| `--tag`/`--case` filter matches nothing | exit 1 | `ERROR`/exit 2, with a message |
| Empty `cases_yade.list` | `WARNING` + exit **0** | `ERROR`/exit 2 |
| `reg_signal_name` outside {6,9,11,15} | `SIG<N>` | the standard names (`SIGINT`, …) |

The DEM one closed a false-green path that contradicted the documented outcome contract ("the only green suite is one where at least one case ran and every case PASSed"). Skip the DEM suite by not invoking its driver, not by emptying its inventory.

Deferred, per the plan's own escape clause: **no serial-case timeout**. It could not be added without either wrapping and masking the case's exit status or risking leaked children. The DEM runner keeps the only real timeout (`setsid` + `timeout`, process-group scoped).

## Verification

**Static:** `bash -n` on all five scripts, `py_compile` on both Python tools, no `pkill`/`killall`/external-tool invocation in any regression shell script, and `regressionState.py` verified stdlib-only by AST.

**Failure-path matrix**, driving the real scripts against stub cases in `/scratch` (no mocks), sequential and 3-wide:

- full taxonomy — `PASS`/`FAIL`/`ERROR`(missing dir, missing baseline, dirty slate, failed clean, no output, missing comparator)/`TIMEOUT`/`CRASH (SIGABRT)` with the correct signal number and name;
- default output identical to `--jobs 1` modulo elapsed times;
- peak concurrent cases provably ≤ `--jobs` (stubs record their own overlap windows); every case runs exactly once; no orphan processes afterwards;
- one passing case cannot mask a crashing one; suite exit non-zero for any abnormal child;
- a reused state directory reports a fresh crash, not the previous `PASS`;
- `events.ndjson` stays parseable with quotes, tabs, newlines and non-ASCII in paths and messages;
- DEM: `--timeout` → 124 with the process group gone, and each DEM assertion failure (`RUN FINISH`, coupling handshake, sphere/spring VTK, `dtInfo`) mapping onto the shared taxonomy.

**Real fast tier**, built solver, sequential vs `--jobs 4`: identical 19-case selection and order, **identical per-case classification**, identical scalar-comparison counts for every passing case, no scheduler- or wrapper-attributable `ERROR`/`TIMEOUT`. Wall clock 86 s → 45 s. `--tag fast --no-run` → 19/19 `PASS`.

### The fast tier is red in my working tree, and it is not this change

The tier reported `CRASH (SIGABRT)` for a varying subset (5, 5, 3, 2 cases across runs). Isolated to the environment, not the scripts, with the same solver binary throughout:

| Scripts | Location | Result |
|---|---|---|
| this branch | bound `KVM-share` working tree | 5 crashes |
| **`main` (`23451bd`) unchanged** | **same working tree** | **the same 5 crashes** |
| this branch | `git worktree` of `23451bd` under `/scratch` (ext4) | **19/19 PASS** |
| `main` unchanged | same `/scratch` worktree | 19/19 PASS |

`--no-run` on the red tree gives 19/19 `PASS`: every case produced output matching its baseline, and only the exit status is wrong. This is the tracked post-`End` teardown heap-corruption defect, and the new data point is that it correlates with the filesystem the case runs on — useful for whoever reproduces it. The pre-push hook was therefore skipped once for this branch.

**Not verified: the real DEM suite.** `build-pgf --yade` cannot compile this tree — `porousGasificationFoam.C:117` calls `lambdaDotUpdater->update()`, but `porousGasificationMedia/DEM/lambdaDotModel.H` declares only `updateLambdaDot()` and `updateParticleFields()`. Pre-existing and out of scope here (this PR touches no solver source), so `Allrun.yade` and `runDEMCase.sh` were exercised against stub DEM cases instead, including a real process-group timeout.
