### PR TITLE
Update volPyrolysis.C

### DIFF
--- a/porousGasificationMedia/pyrolysisModels/pyrolysisModel/volPyrolysis/volPyrolysis.C
+++ b/porousGasificationMedia/pyrolysisModels/pyrolysisModel/volPyrolysis/volPyrolysis.C
@@ -144,7 +144,8 @@ void volPyrolysis::solvePorosity()
             fvm::ddt(por)
          ==
             porositySource_
-          - fvc::div(phiUs,por,"div(phiSolid)")
+          + fvc::div(Us)
+          - fvc::div(Us, por, "div(phiSolid)")
         );
 
         porosityEqn.solve("porosity");

--- a/porousGasificationMedia/pyrolysisModels/pyrolysisModel/volPyrolysis/volPyrolysis.C
+++ b/porousGasificationMedia/pyrolysisModels/pyrolysisModel/volPyrolysis/volPyrolysis.C
@@ -136,6 +136,8 @@ void volPyrolysis::solvePorosity()
         volScalarField& por = porosity_;
 
         surfaceScalarField phiUs = mesh_.Sf() & fvc::interpolate(Us_,"Us");
+        
+        surfaceScalarField Us (mesh_.Sf() & fvc::interpolate(Us_, "Us"));
 
         // requires setting same stuff as for diffusion to release flux at the ends of porous media
         // it would be best to solve 1-porosity as it gives 0 flux naturally when empty?? 

--- a/porousGasificationMedia/pyrolysisModels/pyrolysisModel/volPyrolysis/volPyrolysis.C
+++ b/porousGasificationMedia/pyrolysisModels/pyrolysisModel/volPyrolysis/volPyrolysis.C
@@ -136,18 +136,18 @@ void volPyrolysis::solvePorosity()
         volScalarField& por = porosity_;
 
         surfaceScalarField phiUs = mesh_.Sf() & fvc::interpolate(Us_,"Us");
-        
-        surfaceScalarField Us (mesh_.Sf() & fvc::interpolate(Us_, "Us"));
 
-        // requires setting same stuff as for diffusion to release flux at the ends of porous media
-        // it would be best to solve 1-porosity as it gives 0 flux naturally when empty?? 
+        // Us_ advects solid, so flux must scale with solid fraction
+        // (1-por), not por. From d(1-por)/dt + div(phiUs*(1-por)) =
+        // -porositySource_, negating and expanding div(phiUs*(1-por))
+        // gives d(por)/dt = porositySource_ + div(phiUs) - div(phiUs,por).
         fvScalarMatrix porosityEqn
         (
             fvm::ddt(por)
          ==
             porositySource_
-          + fvc::div(Us)
-          - fvc::div(Us, por, "div(phiSolid)")
+          + fvc::div(phiUs)
+          - fvc::div(phiUs, por, "div(phiSolid)")
         );
 
         porosityEqn.solve("porosity");


### PR DESCRIPTION
## Summary
update fvScalarMatrix porosityEqn to move solid part

## Why
to prevent porosity going above 1

## Verification
<!-- What did you actually run or check? Be specific.
     Examples:
     - Built with `./Allwmake` (or affected sub-target).
     - Tutorial(s) re-run: `tutorials/cases/<name>` — residuals look normal.
     - Regression suite: pass / N/A / baseline not yet captured.
     - Notes on numerical impact (if any).
     Skip if the change cannot affect runtime behaviour (e.g. README only). -->
