### PR TITLE
chore(regression): make the pre-push gate block on regressions, not on red

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,7 +589,67 @@ Some cases run to completion and write correct output, then the solver aborts du
 
 This is a solver/library teardown lifetime defect, tracked separately from the regression tooling. It is **intermittent**: the same binary running the same `fast`-tier case has aborted on every attempt in one environment and completed cleanly on every attempt in another, and the same fault has also been seen to surface as a teardown *hang* rather than an abort. So a green fast tier is evidence about a particular run, not about the code, and a red one is not necessarily a regression introduced by the change under test.
 
-A tracked pre-push hook running the fast tier is therefore deferred until the teardown defect is fixed — a gate that goes red for reasons outside a given change would only train people to bypass it. Do **not** paper over the abort with `|| true`; that would trade an honest CRASH for a false green.
+Do **not** paper over the abort with `|| true`; that would trade an honest CRASH for a false green. The suite reports what the process did, and that does not change. What *can* change is the question a **gate** asks about the result — see [The pre-push gate](#the-pre-push-gate) below.
+
+### The pre-push gate
+
+```bash
+./scripts/install-hooks.sh          # install (refuses to clobber an existing hook)
+./scripts/install-hooks.sh --list   # what is installed now
+./scripts/install-hooks.sh --remove # uninstall
+git push --no-verify                # skip it once
+```
+
+The hook does **not** ask "is the fast tier green?". It cannot: the tier is not
+green on `main`, for two reasons that have nothing to do with whatever you are
+pushing — three cases compare against baselines captured at `4073e55` and never
+regenerated, and the intermittent teardown abort kills a varying subset of cases
+*after* they have written correct output. A gate that demanded green would be
+red on every push, and a gate that is always red only teaches people to type
+`--no-verify`.
+
+So it asks a different question: **did this push make something worse?**
+
+| Case outcome | Gate |
+|---|---|
+| `PASS` | allowed |
+| `CRASH`, output still matches the baseline | reported, allowed |
+| `CRASH`, output does not match | **blocked** |
+| `FAIL` listed in `expected.list` | reported, allowed |
+| `FAIL` not listed | **blocked** |
+| `PASS` but listed as `FAIL` | **blocked** — `expected.list` is now lying |
+| `ERROR` | **blocked** — nothing was compared |
+
+The crash row is the load-bearing one. A `CRASH` result stops at the `run`
+phase, so the suite never got to compare; the hook re-runs `runCase.sh --no-run`
+on the output the aborted case already wrote. That is what separates "died on
+the way out with correct numbers" from "died, and the numbers are wrong".
+
+Nothing about the suite is relaxed to make this work. `Allrun` still reports a
+`CRASH` as a `CRASH` and still exits non-zero; the hook is one of the external
+observers its `--state-dir` interface was built for, and reads per-case
+`result.json` rather than parsing log text.
+
+#### `applications/test/regression/expected.list`
+
+One line per case that is expected not to pass, each with a mandatory reason:
+
+```
+<case path from cases.list>   FAIL   <why, and how it gets fixed>
+```
+
+A case not listed is expected to `PASS`. A malformed line or an unknown status
+aborts the gate rather than being guessed at, and a case listed here that starts
+passing **blocks the push** — that means either the underlying problem is fixed
+or something else drifted, and either way the file needs updating. This is
+deliberate: an expectations file that nobody is forced to revisit rots into a
+list of ignored failures.
+
+The three entries there today are all the same problem — the baselines predate
+five solver commits on `main` and describe a solver that no longer exists.
+Recapturing them is a physics decision (are the current numbers right?), not a
+tooling one, which is why the gate reports the situation on every push instead
+of quietly tolerating it forever.
 
 ### What the comparison does
 

--- a/applications/test/regression/expected.list
+++ b/applications/test/regression/expected.list
@@ -1,0 +1,46 @@
+# Expected outcome of each fast-tier case, for the pre-push gate.
+#
+# The regression suite (Allrun) reports what a case *did*, and it is right to
+# call anything short of PASS not-green. This file is a different question,
+# asked only by the pre-push hook: "is this outcome already true on main, or did
+# the push cause it?" The hook blocks on the second and reports the first.
+#
+# It exists because the fast tier is not green on main, so a gate that demanded
+# green could only ever be bypassed. It is NOT a place to silence a failure you
+# caused. Every entry carries a reason and a way out; an entry with neither is a
+# bug in this file.
+#
+# Format, one case per non-comment line:
+#
+#     <case path from cases.list>   <expected status>   <reason>
+#
+# <expected status> is one of:
+#   PASS   the default for any case not listed here — no entry needed
+#   FAIL   compares out of tolerance, for the stated reason
+#
+# CRASH is deliberately not an expected status. The teardown abort is
+# intermittent (README -> "Known caveat"), so no case can be pinned to it. The
+# hook handles it by re-comparing the output the crashed run already wrote: if
+# the numbers are right, the abort is reported and not blocked on; if they are
+# wrong, it blocks.
+#
+# The hook also blocks when a case listed here PASSes. That is not pedantry —
+# it means either the underlying problem is fixed or something else drifted, and
+# in both cases this file is now lying. Delete the line and say why in the
+# commit.
+
+# ---------------------------------------------------------------------------
+# Stale baselines: captured at 4073e55 (2026-08-04, PR #31), never recaptured.
+#
+# main has taken five solver commits since, several of them in volPyrolysis.C's
+# solid-transport and porosity code: 6322db3 (#35), 2d683ba (#37), 1969061
+# (#36), b2f170a (#38), 23aecda. The solver was changed on purpose and these
+# references were not regenerated, so they describe a solver that no longer
+# exists.
+#
+# Way out: decide the current numbers are right, recapture all three, and state
+# why in the commit (README -> "Capturing the baseline"). That is a physics
+# call, not a tooling one, which is why it has not been made here.
+tutorials/cases/charOnlyMoveCases/serial              FAIL   stale baseline (4073e55); volAverage(Ts) differs by up to 6.8e-02 relative
+tutorials/cases/charOnlyMoveCases/solidInlet          FAIL   stale baseline (4073e55); reference volAverage(Ts) is 0 K on every row, which is not a physical solid temperature
+tutorials/cases/charOnlyMoveCases/solidInlet_tinyDt   FAIL   stale baseline (4073e55); same degenerate reference as solidInlet

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,209 @@
+#!/bin/bash
+# Pre-push gate for porousGasificationFoam.
+#
+# Install with scripts/install-hooks.sh. Skip once with `git push --no-verify`.
+#
+# What this is for
+# ----------------
+# The fast regression tier is not green on main, for two reasons that have
+# nothing to do with any given push:
+#
+#   * three cases compare out of tolerance against baselines captured at
+#     4073e55 and never regenerated (see expected.list);
+#   * an intermittent teardown heap-corruption abort makes a varying subset of
+#     cases die on SIGABRT *after* writing correct output (README -> "Known
+#     caveat: teardown abort surfaces as CRASH").
+#
+# A gate that demanded a green tier would therefore be red on every push, and a
+# gate that is always red teaches people to type --no-verify. So this hook does
+# not ask "is the tier green?". It asks "did this push make something worse?"
+#
+#   PASS                        -> fine
+#   CRASH, numbers still right  -> reported, not blocked (re-compared below)
+#   CRASH, numbers wrong        -> BLOCK
+#   FAIL, listed in expected    -> reported, not blocked
+#   FAIL, not listed            -> BLOCK
+#   PASS but listed as FAIL     -> BLOCK (expected.list is now lying)
+#   ERROR                       -> BLOCK (infrastructure; nothing was compared)
+#
+# The suite itself is untouched and stays as strict as it is: Allrun still
+# reports a CRASH as a CRASH and still exits non-zero. This hook is one of the
+# external observers Allrun's --state-dir interface was built for; it reads
+# per-case result.json and never parses human log output.
+#
+# Nothing here papers over a failure with `|| true`. Every non-blocking outcome
+# is one this file names, with a reason, and prints on every run.
+
+set -u
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+REG_DIR="$REPO_ROOT/applications/test/regression"
+ALLRUN="$REG_DIR/Allrun"
+RUN_CASE="$REG_DIR/tools/runCase.sh"
+EXPECTED="$REG_DIR/expected.list"
+JOBS="${PGF_HOOK_JOBS:-4}"
+
+# If the solver isn't on PATH, OpenFOAM isn't sourced — skip gracefully rather
+# than blocking a docs-only push made from a plain shell.
+if ! command -v porousGasificationFoam >/dev/null 2>&1; then
+    echo "[pre-push] porousGasificationFoam not on PATH — skipping regression tests."
+    echo "[pre-push] Source your OpenFOAM environment first if you want tests to run."
+    exit 0
+fi
+
+if [ ! -x "$ALLRUN" ]; then
+    echo "[pre-push] $ALLRUN missing or not executable — cannot gate this push." >&2
+    exit 1
+fi
+
+STATE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/pgf-prepush.XXXXXX")"
+cleanup() { rm -rf "$STATE_DIR"; }
+trap cleanup EXIT
+
+echo "[pre-push] Running the fast regression tier (--jobs $JOBS)..."
+"$ALLRUN" --tag fast --jobs "$JOBS" --state-dir "$STATE_DIR" >"$STATE_DIR/suite.log" 2>&1
+suiteRc=$?
+
+if [ ! -f "$STATE_DIR/result.json" ]; then
+    echo "[pre-push] The suite produced no result.json (exit $suiteRc) — cannot judge this push." >&2
+    echo "[pre-push] Full log:" >&2
+    cat "$STATE_DIR/suite.log" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Re-compare every crashed case.
+#
+# A CRASH result stops at phase "run", so the suite never got to compare. The
+# output the case wrote before aborting is still on disk, and runCase.sh
+# --no-run compares exactly that. This is the one step that distinguishes "died
+# on the way out with correct numbers" from "died and the numbers are wrong",
+# and it is why a crash is not automatically fatal here.
+# ---------------------------------------------------------------------------
+crashRecheck="$STATE_DIR/crash-recheck.tsv"
+: >"$crashRecheck"
+
+while IFS= read -r caseId; do
+    [ -n "$caseId" ] || continue
+    echo "[pre-push]   re-comparing crashed case: $caseId"
+    if "$RUN_CASE" "$REPO_ROOT/$caseId" --no-run >"$STATE_DIR/recheck.log" 2>&1; then
+        printf '%s\tOK\n' "$caseId" >>"$crashRecheck"
+    else
+        printf '%s\tBAD\n' "$caseId" >>"$crashRecheck"
+    fi
+done < <(
+    python3 - "$STATE_DIR/result.json" <<'PY'
+import json, sys
+with open(sys.argv[1]) as fh:
+    doc = json.load(fh)
+for case in doc.get("cases", []):
+    if case.get("status") == "CRASH":
+        print(case.get("case_id", ""))
+PY
+)
+
+# ---------------------------------------------------------------------------
+# Verdict.
+# ---------------------------------------------------------------------------
+python3 - "$STATE_DIR/result.json" "$EXPECTED" "$crashRecheck" <<'PY'
+import json, sys
+
+result_path, expected_path, recheck_path = sys.argv[1:4]
+
+with open(result_path) as fh:
+    doc = json.load(fh)
+
+# expected.list: "<case path>  <status>  <reason>"; unlisted cases expect PASS.
+expected = {}
+try:
+    with open(expected_path) as fh:
+        for lineno, raw in enumerate(fh, 1):
+            line = raw.split("#", 1)[0].strip()
+            if not line:
+                continue
+            parts = line.split(None, 2)
+            if len(parts) < 3:
+                sys.stderr.write(
+                    f"[pre-push] {expected_path}:{lineno}: needs "
+                    f"'<case> <status> <reason>' — refusing to guess.\n")
+                sys.exit(1)
+            case, status, reason = parts[0], parts[1].upper(), parts[2]
+            if status not in ("PASS", "FAIL"):
+                sys.stderr.write(
+                    f"[pre-push] {expected_path}:{lineno}: status must be "
+                    f"PASS or FAIL, got {status!r}.\n")
+                sys.exit(1)
+            expected[case] = (status, reason)
+except FileNotFoundError:
+    pass  # no expectations recorded: every case is simply expected to pass
+
+recheck = {}
+with open(recheck_path) as fh:
+    for line in fh:
+        if "\t" in line:
+            case, verdict = line.rstrip("\n").split("\t", 1)
+            recheck[case] = verdict
+
+blocking, tolerated = [], []
+
+for case in doc.get("cases", []):
+    cid = case.get("case_id", "?")
+    status = case.get("status", "ERROR")
+    want, reason = expected.get(cid, ("PASS", ""))
+
+    if status == "PASS":
+        if want == "FAIL":
+            blocking.append(
+                (cid, "PASSes, but expected.list still records it as FAIL "
+                      f"({reason}) — remove the line and say why"))
+        continue
+
+    if status == "CRASH":
+        signal = case.get("signal_name", "?")
+        if recheck.get(cid) == "OK":
+            tolerated.append(
+                (cid, f"aborted on {signal} after writing correct output "
+                      "(teardown defect, README -> Known caveat)"))
+        else:
+            blocking.append(
+                (cid, f"aborted on {signal} AND its output does not match the "
+                      "baseline"))
+        continue
+
+    if status == "FAIL":
+        if want == "FAIL":
+            tolerated.append((cid, f"expected failure: {reason}"))
+        else:
+            blocking.append((cid, case.get("message", "compared out of tolerance")))
+        continue
+
+    blocking.append((cid, f"{status}: {case.get('message', 'no detail')}"))
+
+counts = doc.get("counts", {})
+summary = "  ".join(f"{k}={v}" for k, v in sorted(counts.items()))
+print(f"[pre-push] tier: {summary}")
+
+if tolerated:
+    print("[pre-push] known, not caused by this push:")
+    for cid, why in tolerated:
+        print(f"[pre-push]   - {cid}: {why}")
+
+if blocking:
+    print("[pre-push] REGRESSIONS — push blocked:", file=sys.stderr)
+    for cid, why in blocking:
+        print(f"[pre-push]   ! {cid}: {why}", file=sys.stderr)
+    print("[pre-push] Fix these, or run 'git push --no-verify' if you are "
+          "certain they are unrelated.", file=sys.stderr)
+    sys.exit(1)
+
+print("[pre-push] No regression against expected.list — push allowed.")
+PY
+verdict=$?
+
+if [ "$verdict" -ne 0 ]; then
+    echo "[pre-push] Full suite log: $STATE_DIR/suite.log (kept until this shell exits)" >&2
+    trap - EXIT
+    exit 1
+fi
+
+exit 0

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Install the tracked git hooks from scripts/hooks/ into this clone.
+#
+#     ./scripts/install-hooks.sh          install (refuses to clobber)
+#     ./scripts/install-hooks.sh --force  overwrite an existing hook
+#     ./scripts/install-hooks.sh --list   show what is installed now
+#     ./scripts/install-hooks.sh --remove uninstall hooks this script installed
+#
+# Hooks are per-clone and git never installs them for you, which is why the
+# source lives in the repository and this script copies it into place. Copying
+# rather than symlinking is deliberate: a symlink into the worktree would run
+# whatever the checked-out branch happens to contain, so switching to a branch
+# that changes the hook would silently change what gates your push.
+#
+# Worktrees share the main repository's hooks directory, so installing from any
+# worktree installs for all of them.
+
+set -eu
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+SRC_DIR="$SCRIPT_DIR/hooks"
+
+# --git-path resolves correctly from a linked worktree, where .git is a file.
+HOOK_DIR="$(git rev-parse --git-path hooks)"
+case "$HOOK_DIR" in
+/*) ;;
+*) HOOK_DIR="$(git rev-parse --show-toplevel)/$HOOK_DIR" ;;
+esac
+
+MARKER='# managed by scripts/install-hooks.sh'
+MODE="install"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  --force) MODE="force" ;;
+  --list) MODE="list" ;;
+  --remove) MODE="remove" ;;
+  -h | --help)
+    sed -n '2,18p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  *)
+    echo "install-hooks.sh: unknown option '$1'" >&2
+    exit 2
+    ;;
+  esac
+  shift
+done
+
+[ -d "$SRC_DIR" ] || {
+  echo "install-hooks.sh: no hook sources at $SRC_DIR" >&2
+  exit 1
+}
+
+mkdir -p "$HOOK_DIR"
+
+for src in "$SRC_DIR"/*; do
+  [ -f "$src" ] || continue
+  name="$(basename "$src")"
+  dst="$HOOK_DIR/$name"
+
+  case "$MODE" in
+  list)
+    if [ ! -e "$dst" ]; then
+      printf '  %-12s not installed\n' "$name"
+    elif grep -qF "$MARKER" "$dst" 2>/dev/null; then
+      if cmp -s <(grep -vxF "$MARKER" "$dst") "$src"; then
+        printf '  %-12s installed, up to date\n' "$name"
+      else
+        printf '  %-12s installed, DIFFERS from scripts/hooks/%s\n' "$name" "$name"
+      fi
+    else
+      printf '  %-12s present, not managed by this script\n' "$name"
+    fi
+    continue
+    ;;
+  remove)
+    if [ -e "$dst" ] && grep -qF "$MARKER" "$dst" 2>/dev/null; then
+      rm -f "$dst"
+      echo "removed $dst"
+    elif [ -e "$dst" ]; then
+      echo "left $dst alone (not installed by this script)"
+    fi
+    continue
+    ;;
+  esac
+
+  # install / force
+  if [ -e "$dst" ] && [ "$MODE" != "force" ] &&
+    ! grep -qF "$MARKER" "$dst" 2>/dev/null; then
+    echo "install-hooks.sh: $dst already exists and was not installed by this" >&2
+    echo "  script. Inspect it, then re-run with --force to replace it." >&2
+    exit 1
+  fi
+
+  # The marker goes after the shebang so the hook stays executable, and lets
+  # --list and --remove tell our copy from one someone wrote by hand.
+  {
+    head -n 1 "$src"
+    printf '%s\n' "$MARKER"
+    tail -n +2 "$src"
+  } >"$dst"
+  chmod +x "$dst"
+  echo "installed $dst"
+done
+
+if [ "$MODE" = "install" ] || [ "$MODE" = "force" ]; then
+  echo
+  echo "Hooks installed into $HOOK_DIR"
+  echo "Skip one push with: git push --no-verify"
+fi


### PR DESCRIPTION
## Summary

The pre-push hook was untracked, lived only in `.git/hooks`, and pointed at a `scripts/install-hooks.sh` that does not exist in this repository. It ran the fast tier and blocked on anything short of green — which meant it blocked every push.

It now asks **"did this push make something worse?"** instead of **"is the tier green?"**, and it ships in the repo where it can be reviewed.

## Why

The fast tier is not green on `main` and cannot be, for two reasons that have nothing to do with whatever you are pushing:

- Three cases compare against baselines captured at `4073e55` (2026-08-04, #31) and never regenerated, though `main` has taken five solver commits since — `6322db3`, `2d683ba`, `1969061`, `b2f170a`, `23aecda`, several of them in `volPyrolysis.C`'s solid-transport and porosity code.
- The intermittent teardown abort kills a varying subset of cases *after* they have written correct output.

So the only way to push was `--no-verify` — exactly the failure mode the README already predicted ("a gate that goes red for reasons outside a given change would only train people to bypass it").

## What it does now

| Case outcome | Gate |
|---|---|
| `PASS` | allowed |
| `CRASH`, output still matches the baseline | reported, allowed |
| `CRASH`, output does not match | **blocked** |
| `FAIL` listed in `expected.list` | reported, allowed |
| `FAIL` not listed | **blocked** |
| `PASS` but listed as `FAIL` | **blocked** — the file is now lying |
| `ERROR` | **blocked** — nothing was compared |

The crash row is what makes this honest rather than merely lenient. A `CRASH` result stops at phase `run`, so the suite never compared anything; the hook re-runs `runCase.sh --no-run` against the output the aborted case already wrote. That separates "died on the way out with correct numbers" from "died, and the numbers are wrong" — a distinction the old hook could not make.

**Nothing in the suite is relaxed.** `Allrun` still calls a `CRASH` a `CRASH` and still exits non-zero. The hook is one of the external observers `--state-dir` was built for: it reads per-case `result.json` and never parses log output. There is no `|| true` anywhere — every tolerated outcome is one `expected.list` names, with a reason, printed on every run.

`expected.list` blocks when a listed case starts *passing*, so it cannot decay into a list of ignored failures, and it refuses a malformed line or unknown status rather than guessing.

## Files

| | |
|---|---|
| `scripts/hooks/pre-push` | the hook, tracked and reviewable |
| `scripts/install-hooks.sh` | `install` / `--list` / `--remove` / `--force`. Resolves the hooks dir via `git rev-parse --git-path`, so it works from a linked worktree, and **copies rather than symlinks** — a symlink into the worktree would run whatever the checked-out branch contains, so switching branches could silently change what gates your push. |
| `applications/test/regression/expected.list` | the three stale-baseline cases, each with a reason and a way out |
| `README.md` | new "The pre-push gate" section; the "Known caveat" paragraph that declared a tracked hook *deferred* is updated, since this supersedes it |

## Verification

Against the real tier, and — for the paths a live run cannot reach on demand — against a saved suite `result.json`:

- **Real run on `main`:** 11 PASS / 3 FAIL / 5 CRASH. All five crashed cases re-compared clean, all three FAILs matched `expected.list`; the gate allowed the push and printed all eight with reasons.
- **This branch was pushed through the new gate with no `--no-verify`.**
- **Perturbed one number** in `canonical/flow`'s committed baseline → **blocked**, naming the case and `comparison diverged (1 out of tolerance, 0 missing of 4)`. Baseline restored byte-identical.
- **Listed a passing case as `FAIL`** → blocked with `PASSes, but expected.list still records it as FAIL`.
- **Crash re-comparison reporting BAD** → blocked, all 8 named.
- **Malformed line** and **unknown status** → both refused with file and line number; the gate exits non-zero rather than guessing.
- `install-hooks.sh` refuses to overwrite an unmanaged hook without `--force`; `--list` correctly reports *not installed* / *up to date* / *differs* / *unmanaged*.

## Not fixed here

The three stale baselines. Recapturing them means deciding the current numbers are right — a physics call that belongs in its own change with its own justification. The gate now surfaces that decision on every push instead of hiding it.
