### PR TITLE
docs: document the GitHub Issues workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/plan.md
+++ b/.github/ISSUE_TEMPLATE/plan.md
@@ -1,0 +1,43 @@
+---
+name: Plan
+about: A stable problem/objective/deliverables spec — not a running log
+title: "Plan: "
+labels: ""
+assignees: ""
+---
+
+## Problem
+
+Why is this needed? What's broken or missing?
+
+## Objective / Deliverables
+
+What "done" looks like. Concrete outcomes, not implementation steps.
+
+## Plan
+
+One checkbox per block/deliverable, each with a rough time estimate. Check
+a box off when that block actually lands — this is the only part of this
+issue meant to be touched routinely.
+
+- [ ] … (~)
+- [ ] … (~)
+
+## Working details
+
+Full implementation detail — files to touch, approach, step-by-step log,
+work reports, dead ends — lives in the linked `/plans` file, not here:
+
+`/plans/github.com/trymarz/porousGasificationFoam/<active-or-backlog>/<id>.md`
+
+The branch that resolves this issue should be created via this issue's
+**Development** panel ("Create a branch") so it's linked here automatically.
+
+---
+
+**This issue is a stable spec, not a status feed.** Once created, edit the
+Problem/Objective/Deliverables sections only when work on the linked plan
+reveals the original assumptions were wrong — not for routine progress
+updates (those are checklist ticks, or belong in `/plans` instead). Apply a
+`domain:*` label and add this issue to the PGF development project board
+after creating it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file may lag the codebase. Before acting on any specific claim below, sanit
 
 Also flag if the *Last verified* date below predates significant recent commits in the affected area; in that case, propose a refresh rather than acting on stale guidance.
 
-*Last verified: 2026-05-21*
+*Last verified: 2026-09-03*
 
 ## Documentation split
 
@@ -41,6 +41,70 @@ The full human-facing version of this rule is in README → Development Workflow
 - Stage specific files by name (`git add path/to/file`). Avoid `git add -A` / `git add .` — tutorial runs leave behind `processor*/`, `postProcessing/`, time directories, and logs that are not meant for version control.
 - Do not push to `origin` unless the user explicitly asks.
 
+## GitHub Issues Workflow
+
+GitHub Issues + Project #4 ("PGF development") is the current-status source for
+planning on this repo — anyone browsing GitHub should see an accurate
+Problem/Objective/Deliverables and rough progress, without digging through
+`/plans`. `/plans` stays the store for implementation detail (files to touch,
+approach, step log) and is unaffected by this section. (This is
+porousGasificationFoam-specific for now; generalizing it into a reusable
+pattern is tracked as backlog item `github-issues-plans-sync-skill-2026-09-02`
+in agent-corral's `/plans`, not part of this repo's workflow yet.)
+
+**Status mapping** (`/plans` frontmatter `status:` → Project `Status`):
+
+| `/plans` `status:` | Project `Status` |
+|---|---|
+| `backlog` | `Backlog` |
+| `active` | `Ready` |
+| `in_progress` | `In progress` |
+| `done` | `Done` |
+| `superseded` | `Done` (closed, with a note) |
+
+**On creating a new plan for this repo**:
+1. Write the `/plans` file as usual.
+2. Create a matching GitHub issue using the `Plan` template
+   (`.github/ISSUE_TEMPLATE/plan.md`): title `Plan: <same title as the plan's
+   `# Plan: …` heading>`; Problem from the plan's Context → Why; Objective /
+   Deliverables from Context → What + any acceptance criteria; a `Plan`
+   checklist with one box per the plan's `## Approach` Blocks (or, for a
+   backlog item with no Blocks yet, per its logical phases), each with a
+   rough time estimate; `domain:*` label(s) matching the plan's frontmatter
+   `domain:`.
+3. Add the issue to project #4 with `Status` per the mapping above.
+4. Record `github_issue: <N>` in the plan's frontmatter (see AGENT-KB.md's
+   Plan Metadata field table).
+
+**As each block lands**: tick that block's checkbox on the issue. This is the
+routine, cheap touchpoint — a checkbox flip, not a rewrite. Nothing else on
+the issue should change for routine progress.
+
+**Body edits are explicit and rare**: only rewrite Problem/Objective/
+Deliverables when work on the plan proves the original spec wrong — flag it
+to the user first, then correct deliberately. Never edit the spec as a side
+effect of routine progress; that belongs in `/plans`' step log instead.
+
+**Before starting work tied to an issue number**: fetch the issue's current
+body + recent comments (`gh issue view <N> --comments`) and compare against
+what `/plans` last recorded. If it diverged — the user edited the issue
+directly — reconcile by discussing with the user; never silently overwrite
+either side.
+
+**Anyone can edit either side.** This isn't an exclusivity rule — it's a
+"don't let the public-facing copy go stale" discipline. The freshness
+guarantee comes from checking in at the right moments, not from restricting
+who writes where.
+
+**Branch / PR linkage**: create the branch that resolves an issue via the
+issue's own **Development** panel → "Create a branch", so GitHub links it
+automatically — don't link it by hand. That auto-generated branch name
+(`<issue-number>-<slug>`) becomes this repo's worktree `<short-name>` (see
+`/plans` memory: `worktree-layout-main-in-primary`). PR bodies include
+`Closes #<issue>` so merging auto-closes the issue, which the project's
+"item closed → Done" workflow rule then moves the card to `Done`
+automatically — no manual board edit needed.
+
 ## Verification habits
 
 - **Before claiming a file, symbol, or flag exists, verify it.** Grep or read the file. Memory and prior conversation context are not authoritative; the current tree is.
@@ -67,3 +131,4 @@ When you need a load-bearing fact, go to the README rather than re-deriving it f
 | Build targets and dependencies | "Build System" |
 | Common failure modes | "Troubleshooting" |
 | Regression framework — hook a case, capture a baseline, run comparisons | "Regression Testing" |
+| GitHub Issues workflow — issue-per-plan creation, checkbox ticks, reconciliation, branch/PR linkage | "GitHub Issues Workflow" (this file, not the README) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,10 +44,13 @@ The full human-facing version of this rule is in README → Development Workflow
 ## GitHub Issues Workflow
 
 GitHub Issues + Project #4 ("PGF development") is the current-status source for
-planning on this repo — anyone browsing GitHub should see an accurate
-Problem/Objective/Deliverables and rough progress, without digging through
-`/plans`. `/plans` stays the store for implementation detail (files to touch,
-approach, step log) and is unaffected by this section. (This is
+planning on this repo — the issue itself (public, like this repo) should show
+an accurate Problem/Objective/Deliverables and rough progress without digging
+through `/plans`. The project board is currently private to the maintainer
+(unlike the repo and its issues), so don't imply board access when writing for
+an external audience — cite the issue by number/label/state instead.
+`/plans` stays the store for implementation detail (files to touch, approach,
+step log) and is unaffected by this section. (This is
 porousGasificationFoam-specific for now; generalizing it into a reusable
 pattern is tracked as backlog item `github-issues-plans-sync-skill-2026-09-02`
 in agent-corral's `/plans`, not part of this repo's workflow yet.)

--- a/README.md
+++ b/README.md
@@ -763,6 +763,10 @@ Examples: `feature/UsInterp-laplace-smoothing`, `fix/regression-allrun-set-u`, `
 
 A single branch may bundle multiple low-risk meta concerns (e.g. formatter, docs, and dev-workflow changes can ride on one `chore/...` branch). Anything that can affect numerical results stays on its own branch.
 
+### Issue Tracking
+
+Planning work has a matching GitHub Issue on [project #4 "PGF development"](https://github.com/users/trymarz/projects/4) — that board is the place to check current status (Backlog/Ready/In progress/In review/Done), not `/plans` (a private planning store used for the deeper working detail — files to touch, approach, step-by-step log). Start the branch that resolves an issue from that issue's own **Development** panel ("Create a branch") so GitHub links the two automatically, and include `Closes #<issue>` in the PR body so merging the PR closes the issue and moves its board card to `Done` on its own.
+
 ### Merge Strategy
 
 The repository uses **squash merge** — each PR becomes one commit on `main`, whose message is the PR title followed by the PR body. This keeps `main` linear and easy to scan with `git log --oneline`, while preserving the *why* and verification context inside `git log` / `git show`.

--- a/README.md
+++ b/README.md
@@ -765,7 +765,7 @@ A single branch may bundle multiple low-risk meta concerns (e.g. formatter, docs
 
 ### Issue Tracking
 
-Planning work has a matching GitHub Issue on [project #4 "PGF development"](https://github.com/users/trymarz/projects/4) — that board is the place to check current status (Backlog/Ready/In progress/In review/Done), not `/plans` (a private planning store used for the deeper working detail — files to touch, approach, step-by-step log). Start the branch that resolves an issue from that issue's own **Development** panel ("Create a branch") so GitHub links the two automatically, and include `Closes #<issue>` in the PR body so merging the PR closes the issue and moves its board card to `Done` on its own.
+Planning work has a matching GitHub Issue (public, like this repo) tracked on a project board named "PGF development" — that's the place to check current status (Backlog/Ready/In progress/In review/Done), not `/plans` (a private planning store used for the deeper working detail — files to touch, approach, step-by-step log). The board itself is currently private to the maintainer, so external contributors should rely on the issue's own labels/state rather than the board view. Start the branch that resolves an issue from that issue's own **Development** panel ("Create a branch") so GitHub links the two automatically, and include `Closes #<issue>` in the PR body so merging the PR closes the issue and moves its board card to `Done` on its own.
 
 ### Merge Strategy
 


### PR DESCRIPTION
## Summary
- Adds `.github/ISSUE_TEMPLATE/plan.md`, the single issue template for the `/plans` -> GitHub Issues migration.
- Adds an "GitHub Issues Workflow" section to AGENTS.md: status mapping, issue-per-plan creation on project #4 ("PGF development"), checkbox-tick-on-block-landing as the routine touchpoint, explicit-only spec-correction rule, pre-work reconciliation, branch/PR linkage.
- Adds a short "Issue Tracking" note to README.md's Development Workflow section for human contributors, and clarifies that the project board is currently private to the maintainer even though the repo and its issues are public.

## Why
Plans lived only in a private `/plans` git store, invisible on GitHub. This gives every plan a matching GitHub Issue so status/progress is visible without digging through `/plans`, while keeping `/plans` as the deep-detail store. Full design history and delivery log: `github-issues-kanban-migration-2026-09-02` (archived in `/plans`).

## Verification
Docs-only change (README.md, AGENTS.md, one new issue template) — no solver source touched. Not expected to affect build or regression behavior; pushed with `--no-verify` for that reason, at the user's explicit direction, rather than waiting on the full regression tier for a docs diff.